### PR TITLE
fix: UDP PCM audio distortion and pacing reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,7 @@ STACKCHAN_AUDIO_MODE="wav"
 STACKCHAN_PCM_TRANSPORT="tcp"
 STACKCHAN_AUDIO_TRANSPORT="tcp"
 STACKCHAN_PCM_STREAM_PORT="9090"
+# Clamped to [0.85, 1.5]; values below 1.0 send UDP frames faster than real time to build buffer margin.
 STACKCHAN_UDP_PACE_FACTOR="1.0"
 STACKCHAN_PCM_GAIN="1.0"
 STACKCHAN_PCM_LIMIT="0.90"

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ AUDIO_SERVE_PORT="5099"
 
 # TTS / ASR.
 TTS_ENGINE="fish-audio"
+STACKCHAN_AUDIO_MODE="wav"
+STACKCHAN_PCM_TRANSPORT="tcp"
+STACKCHAN_AUDIO_TRANSPORT="tcp"
+STACKCHAN_PCM_STREAM_PORT="9090"
+STACKCHAN_UDP_PACE_FACTOR="1.0"
+STACKCHAN_PCM_GAIN="1.0"
+STACKCHAN_PCM_LIMIT="0.90"
 FISH_AUDIO_KEY="replace-with-your-fish-audio-api-key"
 FISH_AUDIO_MODEL_ZH="replace-with-your-chinese-voice-model-id"
 FISH_AUDIO_MODEL_EN="replace-with-your-english-voice-model-id"

--- a/docs/audio-playback-noise-troubleshooting-2026-05-28.md
+++ b/docs/audio-playback-noise-troubleshooting-2026-05-28.md
@@ -153,18 +153,19 @@ serial behavior is a WAV validation error and no speaker playback.
 
 ## 2026-05-29 Follow-up: MCP PCM Streaming Noise
 
-After the WAV download fix, crackling still occurred during normal MCP speech.
-That path now uses Fish Audio PCM streaming by default, so the follow-up work
-focused on the `/play/pcm` route rather than the WAV `/play` route.
+After the WAV download fix, crackling still occurred during Fish Audio PCM
+speech. Later follow-up work focused on the `/play/pcm` route rather than the
+WAV `/play` route. The host now defaults to `STACKCHAN_AUDIO_MODE=wav` for
+normal speech; use `auto` or `pcm` only when explicitly testing PCM transports.
 
 Additional mitigations now in place:
 
-- `STACKCHAN_AUDIO_MODE=auto|pcm|wav` can force PCM or WAV for isolation.
+- `STACKCHAN_AUDIO_MODE=auto|pcm|wav` can select PCM or WAV for isolation.
 - `STACKCHAN_SAVE_PCM=1` saves the original Fish PCM stream under
   `/tmp/stackchan_audio/diag_<session>.pcm`.
 - PCM streaming applies host-side gain and limiting before device playback:
-  `STACKCHAN_PCM_GAIN` defaults to `0.75`, and `STACKCHAN_PCM_LIMIT` defaults
-  to `0.90`.
+  `STACKCHAN_PCM_GAIN` defaults to `1.0`, and `STACKCHAN_PCM_LIMIT` defaults to
+  `0.90`.
 - PCM segments are cut near a low-amplitude sample when possible
   (`STACKCHAN_PCM_ZERO_CROSS_WINDOW`, default `256`) and get a short de-click
   ramp at the next segment start (`STACKCHAN_PCM_DECLICK_SAMPLES`, default

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -217,11 +217,31 @@ WAV playback is push-based:
 The WAV playback path expects data suitable for the device. The MCP server
 converts generated TTS to 24 kHz, mono, signed 16-bit WAV.
 
-For lower latency speech, firmware also accepts `POST /play/pcm` with raw PCM:
+For lower latency speech, firmware accepts raw PCM without using WAV as the
+live transport:
+
+- TCP PCM stream on port `9090`: the MCP server sends
+  `STACKCHAN_PCM_STREAM/1 session=<id> rate=24000 channels=1 width=2\n`, waits
+  for `OK\n`, then sends raw 24 kHz mono signed 16-bit little-endian PCM until
+  TCP EOF. Firmware prebuffers about 120 ms, then writes 10 ms frames to an
+  ESP-IDF I2S DMA backend configured for the CoreS3 speaker amplifier. This path
+  is experimental until audible playback is verified on the device.
+- UDP PCM session: the MCP server starts `POST /audio/session`, receives a
+  session token and UDP port, then sends 10 ms `24 kHz` mono signed 16-bit
+  little-endian PCM frames as `SCP1` datagrams. Firmware tracks sequence
+  numbers, fills missing frames with silence, and writes frames through the same
+  I2S DMA backend. This remains available for experiments where lossy low-level
+  datagrams are acceptable.
+- HTTP staged PCM through `POST /play/pcm?mode=staged`: MCP sends bounded
+  segments with `X-Stackchan-Pcm-Mode: staged`; firmware joins them in PSRAM
+  and starts playback only after the final segment. This remains the fallback
+  PCM path when TCP cannot connect before playback starts.
+
+The legacy immediate HTTP PCM segment path remains available for direct tests:
 
 - Format: 24 kHz, mono, signed 16-bit little-endian.
 - Content type: `audio/x-raw;format=s16le;rate=24000;channels=1`.
-- MCP sends PCM in 48 KiB segments and firmware accepts later segments with
+- MCP can send PCM in 48 KiB segments and firmware accepts later segments with
   `202 Accepted` while the current PCM segment is playing.
 - Each PCM segment includes `session`, `seq`, and `final` metadata. MCP sends
   these as `X-Stackchan-Pcm-Session`, `X-Stackchan-Pcm-Seq`, and
@@ -253,23 +273,27 @@ For lower latency speech, firmware also accepts `POST /play/pcm` with raw PCM:
   MCP clients to fetch through `/audio`.
 - Playback timeout clears any queued PCM segments before resuming normal audio
   queue processing, so stale segments from a broken stream are not replayed.
-- The MCP server posts Fish PCM in bounded segments so playback can start
-  before the full TTS response has completed. Each segment is still sent as a
-  normal HTTP request with `Content-Length`, because the ESP32 `WebServer`
-  handler is not compatible with chunked request bodies.
-- The MCP server tries Fish Audio PCM streaming first when `TTS_ENGINE` is
-  `fish-audio` and `FISH_AUDIO_KEY` is set. If streaming setup or playback
-  fails before any PCM segment is accepted, it falls back to the existing WAV
-  `/play` path. If a later PCM segment fails after audio has started, MCP
-  returns an error instead of falling back to WAV to avoid duplicate speech.
-- Set `STACKCHAN_AUDIO_MODE=wav` to force the validated WAV path, `pcm` to
-  force PCM without fallback, or `auto` for the default behavior. Set
+- The MCP server defaults to `STACKCHAN_AUDIO_MODE=wav`, using the validated
+  `M5.Speaker` WAV path for normal speech.
+- Set `STACKCHAN_AUDIO_MODE=auto` or `pcm` only for PCM experiments. In those
+  modes the MCP server tries Fish Audio PCM first if `TTS_ENGINE` is
+  `fish-audio` and `FISH_AUDIO_KEY` is set. In `auto` mode, if PCM setup or
+  upload fails before audio starts, it falls back to the existing WAV `/play`
+  path. If PCM fails after audio has started, MCP returns an error instead of
+  falling back to WAV to avoid duplicate speech.
+- `STACKCHAN_PCM_TRANSPORT=tcp` selects the TCP PCM stream when PCM mode is
+  enabled. `auto` tries TCP, then staged HTTP PCM. Set
+  `STACKCHAN_PCM_TRANSPORT=staged` to skip streaming transports, or `tcp`/`udp`
+  to require a specific stream path. UDP is kept as an explicit experimental
+  path and is not used by transport `auto`.
+- Use `wav` for normal speech, `auto` for PCM with WAV fallback, or `pcm` to
+  force PCM without fallback. Set
   `STACKCHAN_SAVE_PCM=1` to save streamed Fish PCM as
-  `/tmp/stackchan_audio/diag_<session>.pcm` for offline inspection. PCM
-  streaming applies conservative gain/peak limiting before sending to the
-  device; tune with `STACKCHAN_PCM_GAIN` and `STACKCHAN_PCM_LIMIT`. It also
-  chooses segment boundaries near low-amplitude samples and smooths a short
-  ramp at PCM segment boundaries to reduce clicks from `playRaw()` transitions.
+  `/tmp/stackchan_audio/diag_<session>.pcm` for offline inspection. PCM applies
+  peak limiting with `STACKCHAN_PCM_GAIN` defaulting to `1.0` and
+  `STACKCHAN_PCM_LIMIT` defaulting to `0.90`. It also chooses segment
+  boundaries near low-amplitude samples and smooths a short ramp at PCM segment
+  boundaries.
 
 Safe playback smoke tests:
 
@@ -277,12 +301,11 @@ Safe playback smoke tests:
 # Non-destructive device reachability check.
 curl -sS --max-time 5 "http://$STACKCHAN_IP/face"
 
-# MCP TTS path. With Fish Audio credentials this tries segmented PCM first;
-# without them it uses the validated WAV fallback.
+# MCP TTS path. By default this uses the validated WAV path.
 MAC_IP="$MAC_IP" STACKCHAN_IP="$STACKCHAN_IP" \
   uv run python -m mcp_server.server
 
-# Force WAV for crackle/noise isolation.
+# Explicitly keep the stable WAV path for crackle/noise isolation.
 STACKCHAN_AUDIO_MODE=wav MAC_IP="$MAC_IP" STACKCHAN_IP="$STACKCHAN_IP" \
   uv run python -m mcp_server.server
 
@@ -393,10 +416,15 @@ Important environment variables:
 - `TTS_ENGINE`: `fish-audio` or `edge-tts`.
 - `FISH_AUDIO_KEY`: required for Fish Audio TTS/ASR.
 - `EDGE_TTS_BIN`: path to `edge-tts` when using the edge TTS fallback.
-- `STACKCHAN_AUDIO_MODE`: `auto`, `pcm`, or `wav`; useful for isolating PCM
-  streaming noise from WAV playback behavior.
+- `STACKCHAN_AUDIO_MODE`: `wav` by default; use `auto` to try PCM with WAV
+  fallback or `pcm` to force PCM without fallback.
+- `STACKCHAN_PCM_TRANSPORT`: `tcp` by default when PCM mode is enabled; use
+  `auto` for TCP/staged fallback, `staged` to force HTTP staged PCM, or
+  `tcp`/`udp` to require a specific stream path. UDP is experimental and only
+  used when explicitly selected.
+- `STACKCHAN_PCM_STREAM_PORT`: TCP PCM port, default `9090`.
 - `STACKCHAN_SAVE_PCM`: set to `1` to save streamed PCM diagnostic files.
-- `STACKCHAN_PCM_GAIN`: PCM streaming gain before playback, default `0.75`.
+- `STACKCHAN_PCM_GAIN`: PCM streaming gain before playback, default `1.0`.
 - `STACKCHAN_PCM_LIMIT`: PCM streaming peak limit as full-scale ratio, default
   `0.90`.
 - `STACKCHAN_PCM_DECLICK_SAMPLES`: samples smoothed at each PCM segment

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -8,10 +8,23 @@ This is the shared contract between the CoreS3 firmware and the MCP server.
   - JSON body: `{"voice_url":"http://.../file.wav"}`
   - Queues a WAV URL for device-side download and playback.
 
+- `POST /audio/session`
+  - JSON body: `{"codec":"pcm_s16le","sample_rate":24000,"channels":1,"sample_width":2,"frame_ms":10}`.
+  - Starts a low-latency UDP PCM session.
+  - Returns `session`, `token`, and `udp_port`.
+  - Audio datagrams use magic `SCP1`, version `1`, the returned token, a
+    sequence number, sample timestamp, payload length, and one 10 ms PCM frame.
+  - An end packet uses the same header with `flags=1` and no payload.
+
+- `DELETE /audio/session/<session>`
+  - Stops the active UDP PCM session.
+
 - `POST /play/pcm?session=<id>&seq=<n>&final=<0|1>`
   - Body: raw PCM bytes.
   - Format: `24 kHz`, mono, signed 16-bit little-endian PCM.
   - Content type: `audio/x-raw;format=s16le;rate=24000;channels=1`.
+  - `mode=staged` or `X-Stackchan-Pcm-Mode: staged` buffers all segments in
+    PSRAM and starts playback only after the final segment.
   - PCM metadata can also be sent with headers:
     `X-Stackchan-Pcm-Session`, `X-Stackchan-Pcm-Seq`, and
     `X-Stackchan-Pcm-Final`. Headers are preferred for raw uploads; query
@@ -20,6 +33,16 @@ This is the shared contract between the CoreS3 firmware and the MCP server.
     increasing `seq` order.
   - Firmware request body limit: `128 KiB`.
   - MCP total PCM payload limit: `2 MiB`.
+
+- TCP PCM stream on port `9090`
+  - Client sends one ASCII header line:
+    `STACKCHAN_PCM_STREAM/1 session=<id> rate=24000 channels=1 width=2\n`.
+  - Firmware replies `OK\n` or `ERR <code>\n`.
+  - After `OK\n`, the client sends raw `24 kHz`, mono, signed 16-bit
+    little-endian PCM bytes until TCP EOF.
+  - This is the default live PCM transport. Firmware prebuffers about 120 ms,
+    writes 10 ms frames to the CoreS3 speaker through ESP-IDF I2S DMA, and
+    exposes stream diagnostics through `/playback/status`.
 
 ## Recording
 
@@ -58,6 +81,7 @@ This is the shared contract between the CoreS3 firmware and the MCP server.
 - `GET /servo/status`
 - `GET /playback/status`
   - Includes playback state, PCM queue depth, audio queue depth, download
-    queue depth, and whether a WAV download is currently in flight.
+    queue depth, UDP/TCP PCM stream state, and whether a WAV download is
+    currently in flight.
 - `GET /snapshot`
   - Returns a JPEG image.

--- a/docs/pcm-playback-stutter-troubleshooting-2026-07-04.md
+++ b/docs/pcm-playback-stutter-troubleshooting-2026-07-04.md
@@ -76,14 +76,17 @@ Fish Audio WAV/zh mode=wav timing[tts=1653ms validate=0ms status=268ms play_post
 - A configurable `STACKCHAN_PCM_FIRST_SEGMENT_TIMEOUT(_SEC)` was added as a
   guard for slow pre-playback PCM startup, though it does not solve slow segment
   upload after playback has begun.
+- Follow-up firmware and host changes now provide non-WAV PCM paths for
+  experiments: TCP sends raw 24 kHz mono s16le over a reliable socket, and UDP
+  sends framed datagrams. The normal MCP speech path remains WAV until audible
+  PCM playback is verified on the device.
 
 ## Follow-up Options
 
-- Keep production speech on `STACKCHAN_AUDIO_MODE=wav` until PCM transport is
-  redesigned.
-- For a real PCM fix, avoid host-to-device raw PCM push for continuous audio:
-  consider a firmware pull model, larger device-side buffering, or SD-backed
-  staging before playback.
+- Use `STACKCHAN_AUDIO_MODE=wav` for normal speech. Use `auto` only when testing
+  PCM with WAV fallback, `pcm` to force PCM without fallback, `tcp`/`staged` to
+  isolate PCM transport behavior, or `udp` to require the experimental UDP
+  stream.
 - If PCM is kept for experiments, add per-segment post timing telemetry to
   confirm whether bottlenecks are Fish streaming, HTTP upload, or firmware
   queue handling.

--- a/docs/pcm-playback-stutter-troubleshooting-2026-07-04.md
+++ b/docs/pcm-playback-stutter-troubleshooting-2026-07-04.md
@@ -1,0 +1,89 @@
+# PCM Playback Stutter Troubleshooting - 2026-07-04
+
+## Symptoms
+
+- Stack-chan speech intermittently cut out or arrived with long gaps when using
+  Fish Audio PCM streaming through `POST /play/pcm`.
+- Device status after playback was healthy: playback idle, empty queues, no
+  audio gate failures, and enough heap/PSRAM.
+
+## Investigation
+
+- Non-destructive device checks:
+
+```sh
+curl -sS --max-time 5 http://10.83.20.187/playback/status
+curl -sS --max-time 5 http://10.83.20.187/audio/status
+curl -sS --max-time 5 http://10.83.20.187/face
+```
+
+- `/playback/status` showed `queued_pcm_segments=0`, `audio_queue_depth=0`,
+  `download_queue_depth=0`, and no `audio_gate_failed_acquire_count`.
+- Short direct PCM tests completed, but first segment posting took around
+  6.3-6.5 seconds.
+- A longer direct PCM test initially failed before playback with:
+
+```text
+invalid PCM payload size: 629
+```
+
+- After fixing odd byte chunk handling locally, longer PCM tests completed but
+  still took far longer than audio duration:
+
+```text
+segments=8 bytes=383266 timing[pcm_total=45361ms first_segment_posted=6936ms]
+segments=10 bytes=481348 timing[pcm_total=57735ms first_segment_posted=8289ms]
+segments=11 bytes=512556 timing[pcm_total=62598ms first_segment_posted=7524ms]
+```
+
+- 24 kHz mono s16le PCM requires about 48 KB/s for real-time playback. The
+  observed host-to-device PCM push path was closer to 8 KB/s in these tests.
+
+## Root Cause / Current Best Hypothesis
+
+There are two separate issues:
+
+1. Fish Audio PCM stream chunks are not guaranteed to align to 16-bit sample
+   boundaries. The host code assumed each chunk length was even, so odd chunks
+   could abort PCM and trigger WAV fallback.
+2. Even when chunk boundaries are handled, the current HTTP `POST /play/pcm`
+   push path is too slow to sustain real-time playback for longer utterances.
+   Firmware receives bounded PCM segments, but segment uploads complete slower
+   than Stack-chan can play them, causing audible gaps.
+
+This is not currently a heap, PSRAM, queue-depth, or audio-gate exhaustion
+problem.
+
+## Mitigation Applied
+
+- Local `.env` was changed to:
+
+```sh
+STACKCHAN_AUDIO_MODE="wav"
+```
+
+- MCP server was restarted with `./start-http.sh stop && ./start-http.sh`.
+- WAV path test completed quickly and played continuously:
+
+```text
+Fish Audio WAV/zh mode=wav timing[tts=1653ms validate=0ms status=268ms play_post=60ms playback_wait=1108ms say_total=3089ms]
+```
+
+## Code Fix
+
+- Host PCM upload now carries a trailing partial sample byte across Fish stream
+  chunks instead of rejecting odd-length chunks immediately.
+- A configurable `STACKCHAN_PCM_FIRST_SEGMENT_TIMEOUT(_SEC)` was added as a
+  guard for slow pre-playback PCM startup, though it does not solve slow segment
+  upload after playback has begun.
+
+## Follow-up Options
+
+- Keep production speech on `STACKCHAN_AUDIO_MODE=wav` until PCM transport is
+  redesigned.
+- For a real PCM fix, avoid host-to-device raw PCM push for continuous audio:
+  consider a firmware pull model, larger device-side buffering, or SD-backed
+  staging before playback.
+- If PCM is kept for experiments, add per-segment post timing telemetry to
+  confirm whether bottlenecks are Fish streaming, HTTP upload, or firmware
+  queue handling.

--- a/docs/pcm-playback-stutter-troubleshooting-2026-07-04.md
+++ b/docs/pcm-playback-stutter-troubleshooting-2026-07-04.md
@@ -12,9 +12,9 @@
 - Non-destructive device checks:
 
 ```sh
-curl -sS --max-time 5 http://10.83.20.187/playback/status
-curl -sS --max-time 5 http://10.83.20.187/audio/status
-curl -sS --max-time 5 http://10.83.20.187/face
+curl -sS --max-time 5 http://$STACKCHAN_IP/playback/status
+curl -sS --max-time 5 http://$STACKCHAN_IP/audio/status
+curl -sS --max-time 5 http://$STACKCHAN_IP/face
 ```
 
 - `/playback/status` showed `queued_pcm_segments=0`, `audio_queue_depth=0`,

--- a/firmware/src/http_server.cpp
+++ b/firmware/src/http_server.cpp
@@ -1,5 +1,6 @@
 #include <M5Unified.h>
 #include <WebServer.h>
+#include <uri/UriBraces.h>
 #include <ArduinoJson.h>
 #include "http_server.h"
 #include "types.h"
@@ -11,6 +12,7 @@
 #include "recording_store.h"
 #include "pcm_upload.h"
 #include "audio_gate.h"
+#include "pcm_stream_service.h"
 
 static WebServer server(80);
 
@@ -20,6 +22,7 @@ static long     s_pcm_diag_next_seq = 0;
 static const char* PCM_HEADER_SESSION = "X-Stackchan-Pcm-Session";
 static const char* PCM_HEADER_SEQ = "X-Stackchan-Pcm-Seq";
 static const char* PCM_HEADER_FINAL = "X-Stackchan-Pcm-Final";
+static const char* PCM_HEADER_MODE = "X-Stackchan-Pcm-Mode";
 
 // ────────────────────────────────────────────
 // POST /play
@@ -92,6 +95,8 @@ static void handlePlayPcm() {
     long seq = seqArg.length() ? seqArg.toInt() : -1;
     String finalArg = headerOrArg(PCM_HEADER_FINAL, "final");
     bool finalSegment = finalArg == "1" || finalArg == "true";
+    String pcmMode = headerOrArg(PCM_HEADER_MODE, "mode");
+    bool stagedMode = pcmMode == "staged" || server.arg("staged") == "1" || server.arg("defer") == "1";
     uint8_t* pcmData = upload.data;
 
     long expectedSeq = s_pcm_diag_next_seq;
@@ -113,7 +118,9 @@ static void handlePlayPcm() {
         server.send(409, "application/json", "{\"success\":false,\"error\":\"pcm seq invalid\"}");
         return;
     }
-    PcmPlaybackResult result = startPcmPlayback(pcmData, pcmSize, sessionId, finalSegment);
+    PcmPlaybackResult result = stagedMode
+        ? stagePcmPlayback(pcmData, pcmSize, sessionId, seq, finalSegment)
+        : startPcmPlayback(pcmData, pcmSize, sessionId, finalSegment);
     if (result != PCM_PLAYBACK_OK && result != PCM_PLAYBACK_QUEUED) {
         if (result != PCM_PLAYBACK_SPEAKER_FAILED) {
             free(pcmData);
@@ -139,14 +146,19 @@ static void handlePlayPcm() {
     }
     s_pcm_diag_next_seq = seq + 1;
 
-    Serial.printf("[HTTP] POST /play/pcm -> session=%s seq=%ld bytes=%u final=%s result=%d queued=%s\n",
+    Serial.printf("[HTTP] POST /play/pcm -> session=%s seq=%ld bytes=%u final=%s mode=%s result=%d queued=%s\n",
                   sessionId.c_str(), seq, (unsigned)pcmSize,
-                  finalSegment ? "true" : "false", result,
+                  finalSegment ? "true" : "false", stagedMode ? "staged" : "stream",
+                  result,
                   result == PCM_PLAYBACK_QUEUED ? "true" : "false");
     if (result == PCM_PLAYBACK_QUEUED) {
-        server.send(202, "application/json", "{\"success\":true,\"queued\":true,\"format\":\"s16le\",\"sample_rate\":24000,\"channels\":1}");
+        if (stagedMode) {
+            server.send(202, "application/json", "{\"success\":true,\"queued\":true,\"staged\":true,\"format\":\"s16le\",\"sample_rate\":24000,\"channels\":1}");
+        } else {
+            server.send(202, "application/json", "{\"success\":true,\"queued\":true,\"staged\":false,\"format\":\"s16le\",\"sample_rate\":24000,\"channels\":1}");
+        }
     } else {
-        server.send(200, "application/json", "{\"success\":true,\"queued\":false,\"format\":\"s16le\",\"sample_rate\":24000,\"channels\":1}");
+        server.send(200, "application/json", "{\"success\":true,\"queued\":false,\"staged\":false,\"format\":\"s16le\",\"sample_rate\":24000,\"channels\":1}");
     }
 }
 
@@ -346,14 +358,46 @@ static void handleServoStatus() {
 // ────────────────────────────────────────────
 static void handlePlaybackStatus() {
     PlaybackStatus playback = getPlaybackStatus();
+    PcmStreamStatus stream = getPcmStreamStatus();
     ServoStatus servo = getServoStatus();
     AudioGateStatus audio = getAudioGateStatus();
 
     JsonDocument doc;
-    doc["playing"] = playback.playing;
-    doc["kind"] = playback.pcm ? "pcm" : (playback.playing ? "wav" : "idle");
+    bool streamActive = stream.active || stream.playing;
+    bool udpActive = stream.udpActive || stream.udpPlaying;
+    doc["playing"] = playback.playing || streamActive || udpActive;
+    doc["kind"] = udpActive ? "udp_pcm" : (streamActive ? "pcm_stream" : (playback.pcm ? "pcm" : (playback.playing ? "wav" : "idle")));
     doc["pcm_session"] = playback.pcmSession;
     doc["pcm_final_segment"] = playback.pcmFinalSegment;
+    doc["pcm_stream_enabled"] = stream.enabled;
+    doc["pcm_stream_port"] = stream.port;
+    doc["pcm_stream_active"] = stream.active;
+    doc["pcm_stream_playing"] = stream.playing;
+    doc["pcm_stream_client_connected"] = stream.clientConnected;
+    doc["pcm_stream_session"] = stream.session;
+    doc["pcm_stream_buffered_bytes"] = stream.bufferedBytes;
+    doc["pcm_stream_total_bytes"] = stream.totalBytes;
+    doc["pcm_stream_underruns"] = stream.underruns;
+    doc["udp_audio_enabled"] = stream.udpEnabled;
+    doc["udp_audio_active"] = stream.udpActive;
+    doc["udp_audio_playing"] = stream.udpPlaying;
+    doc["udp_audio_session"] = stream.udpSession;
+    doc["udp_audio_port"] = stream.udpPort;
+    doc["udp_audio_token"] = stream.udpToken;
+    doc["udp_audio_buffered_frames"] = stream.udpBufferedFrames;
+    doc["jitter_ms"] = (unsigned)(stream.udpBufferedFrames * 10);
+    doc["udp_audio_buffered_bytes"] = stream.udpBufferedBytes;
+    doc["frames_received"] = stream.udpFramesReceived;
+    doc["frames_lost"] = stream.udpFramesLost;
+    doc["frames_late"] = stream.udpFramesLate;
+    doc["underruns"] = stream.udpUnderruns;
+    doc["first_audio_ms"] = stream.udpFirstAudioMs;
+    doc["udp_last_end_reason"] = stream.udpLastEndReason;
+    doc["udp_last_frames_received"] = stream.udpLastFramesReceived;
+    doc["udp_last_frames_lost"] = stream.udpLastFramesLost;
+    doc["udp_last_frames_late"] = stream.udpLastFramesLate;
+    doc["udp_last_underruns"] = stream.udpLastUnderruns;
+    doc["udp_last_first_audio_ms"] = stream.udpLastFirstAudioMs;
     doc["current_bytes"] = playback.currentBytes;
     doc["queued_pcm_bytes"] = playback.queuedPcmBytes;
     doc["queued_pcm_segments"] = playback.queuedPcmSegments;
@@ -379,6 +423,70 @@ static void handlePlaybackStatus() {
     String body;
     serializeJson(doc, body);
     server.send(200, "application/json", body);
+}
+
+static bool validateAudioSessionBody() {
+    if (!server.hasArg("plain") || server.arg("plain").length() == 0) {
+        return true;
+    }
+    JsonDocument req;
+    if (deserializeJson(req, server.arg("plain")) != DeserializationError::Ok) {
+        server.send(400, "application/json", "{\"success\":false,\"error\":\"json parse error\"}");
+        return false;
+    }
+    const char* codec = req["codec"] | "pcm_s16le";
+    int sampleRate = req["sample_rate"] | 24000;
+    int channels = req["channels"] | 1;
+    int sampleWidth = req["sample_width"] | 2;
+    int frameMs = req["frame_ms"] | 10;
+    if (strcmp(codec, "pcm_s16le") != 0 || sampleRate != 24000 ||
+        channels != 1 || sampleWidth != 2 || frameMs != 10) {
+        server.send(400, "application/json", "{\"success\":false,\"error\":\"unsupported audio session format\"}");
+        return false;
+    }
+    return true;
+}
+
+static void handleAudioSessionStart() {
+    if (!validateAudioSessionBody()) {
+        return;
+    }
+    UdpPcmSessionResult result = beginUdpPcmSession();
+    if (!result.success) {
+        String body = "{\"success\":false,\"error\":\"";
+        body += result.error;
+        body += "\"}";
+        server.send(409, "application/json", body);
+        return;
+    }
+
+    JsonDocument doc;
+    doc["success"] = true;
+    doc["session"] = result.session;
+    doc["transport"] = "udp";
+    doc["codec"] = "pcm_s16le";
+    doc["sample_rate"] = 24000;
+    doc["channels"] = 1;
+    doc["sample_width"] = 2;
+    doc["frame_ms"] = 10;
+    doc["jitter_ms"] = 40;
+    doc["start_buffer_ms"] = 40;
+    doc["udp_port"] = result.port;
+    doc["token"] = result.token;
+    String body;
+    serializeJson(doc, body);
+    server.send(200, "application/json", body);
+}
+
+static void handleAudioSessionStop() {
+    String prefix = "/audio/session/";
+    String uri = server.uri();
+    String sessionId = uri.startsWith(prefix) ? uri.substring(prefix.length()) : "";
+    if (!stopUdpPcmSession(sessionId)) {
+        server.send(404, "application/json", "{\"success\":false,\"error\":\"session not active\"}");
+        return;
+    }
+    server.send(200, "application/json", "{\"success\":true}");
 }
 
 // ────────────────────────────────────────────
@@ -442,10 +550,13 @@ void initHttpServer() {
         PCM_HEADER_SESSION,
         PCM_HEADER_SEQ,
         PCM_HEADER_FINAL,
+        PCM_HEADER_MODE,
     };
     server.collectHeaders(headerKeys, sizeof(headerKeys) / sizeof(headerKeys[0]));
     server.on("/play",         HTTP_POST, handlePlay);
     server.on("/play/pcm",     HTTP_POST, handlePlayPcm, handlePlayPcmRaw);
+    server.on("/audio/session", HTTP_POST, handleAudioSessionStart);
+    server.on(UriBraces("/audio/session/{}"), HTTP_DELETE, handleAudioSessionStop);
     server.on("/mode",         HTTP_POST, handleMode);
     server.on("/audio/status", HTTP_GET,  handleAudioStatus);
     server.on("/audio",        HTTP_GET,  handleAudio);

--- a/firmware/src/http_server.cpp
+++ b/firmware/src/http_server.cpp
@@ -468,9 +468,9 @@ static void handleAudioSessionStart() {
     doc["sample_rate"] = 24000;
     doc["channels"] = 1;
     doc["sample_width"] = 2;
-    doc["frame_ms"] = 10;
-    doc["jitter_ms"] = 40;
-    doc["start_buffer_ms"] = 40;
+    doc["frame_ms"] = PCM_UDP_FRAME_MS;
+    doc["jitter_ms"] = PCM_UDP_START_FRAMES * PCM_UDP_FRAME_MS;
+    doc["start_buffer_ms"] = PCM_UDP_START_FRAMES * PCM_UDP_FRAME_MS;
     doc["udp_port"] = result.port;
     doc["token"] = result.token;
     String body;

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -9,6 +9,7 @@
 #include "mic_service.h"
 #include "wifi_manager.h"
 #include "playback_service.h"
+#include "pcm_stream_service.h"
 #include "face_service.h"
 #include "servo_service.h"
 #include "camera_service.h"
@@ -44,6 +45,7 @@ void setup() {
 
     connectWiFi();
     initPlayback();
+    initPcmStreamService();
     initHttpServer();
 }
 void loop() {

--- a/firmware/src/pcm_stream_service.cpp
+++ b/firmware/src/pcm_stream_service.cpp
@@ -15,12 +15,13 @@
 #define PCM_UDP_PORT                 9091
 #define PCM_STREAM_SAMPLE_RATE       24000
 #define PCM_STREAM_BYTES_PER_SAMPLE  2
-#define PCM_UDP_FRAME_MS             10
+// PCM_UDP_FRAME_MS / PCM_UDP_START_FRAMES live in pcm_stream_service.h so
+// http_server.cpp can advertise the real preroll in /audio/session.
 #define PCM_UDP_FRAME_SAMPLES        ((PCM_STREAM_SAMPLE_RATE * PCM_UDP_FRAME_MS) / 1000)
 #define PCM_UDP_FRAME_BYTES          (PCM_UDP_FRAME_SAMPLES * PCM_STREAM_BYTES_PER_SAMPLE)
 #define PCM_UDP_SLAB_FRAMES          1
-#define PCM_UDP_START_FRAMES         12
 #define PCM_UDP_RING_FRAMES          512
+#define PCM_UDP_FADE_SAMPLES         64
 #define PCM_UDP_HEADER_BYTES         24
 #define PCM_UDP_PACKET_MAX           (PCM_UDP_HEADER_BYTES + PCM_UDP_FRAME_BYTES)
 #define PCM_UDP_VERSION              1
@@ -77,6 +78,11 @@ static uint32_t s_udpFramesLost = 0;
 static uint32_t s_udpFramesLate = 0;
 static uint32_t s_udpUnderruns = 0;
 static uint32_t s_udpFirstAudioMs = 0;
+// Last mono sample actually written to I2S (for click-free concealment ramps).
+static int16_t s_udpLastSample = 0;
+// True when the previous frame written was concealed (or this is session
+// start) so the next real frame should fade in instead of jumping.
+static bool s_udpConcealedPrev = true;
 static unsigned long s_udpStartedMs = 0;
 static unsigned long s_udpLastPacketMs = 0;
 static String s_udpLastEndReason = "";
@@ -266,6 +272,39 @@ static bool writeUdpI2sFrame(const uint8_t* frame) {
     return true;
 }
 
+// Fills `frame` (PCM_UDP_FRAME_SAMPLES mono int16 samples) with a linear
+// ramp from `fromSample` down to exactly 0 at the last sample. Used both to
+// conceal lost/late frames and to fade out the tail of a session, avoiding
+// the instantaneous jump ("click") a flat-zero fill would cause. Integer
+// math only, int32 intermediates to avoid overflow (max |fromSample| *
+// denom ~= 32768 * 239, well within int32 range).
+static void fillConcealmentRamp(uint8_t* frame, int32_t fromSample) {
+    int16_t* samples = (int16_t*)frame;
+    const int32_t denom = (int32_t)PCM_UDP_FRAME_SAMPLES - 1;
+    for (size_t i = 0; i < PCM_UDP_FRAME_SAMPLES; ++i) {
+        int32_t remaining = denom - (int32_t)i;
+        int32_t value = (fromSample * remaining) / denom;
+        samples[i] = (int16_t)value;
+    }
+}
+
+// Fades in the first PCM_UDP_FADE_SAMPLES samples of `frame` from 0 up to
+// their original value, in place. Used when real audio resumes after one
+// or more concealed frames (or at session start) to avoid a click.
+static void applyFadeIn(uint8_t* frame) {
+    int16_t* samples = (int16_t*)frame;
+    const size_t fadeSamples =
+        (PCM_UDP_FRAME_SAMPLES < PCM_UDP_FADE_SAMPLES) ? PCM_UDP_FRAME_SAMPLES : PCM_UDP_FADE_SAMPLES;
+    if (fadeSamples < 2) {
+        return;
+    }
+    const int32_t denom = (int32_t)fadeSamples - 1;
+    for (size_t i = 0; i < fadeSamples; ++i) {
+        int32_t value = ((int32_t)samples[i] * (int32_t)i) / denom;
+        samples[i] = (int16_t)value;
+    }
+}
+
 static bool writePcmI2s(const uint8_t* data, size_t size) {
     uint8_t frame[PCM_UDP_FRAME_BYTES];
     size_t offset = 0;
@@ -300,6 +339,8 @@ static void resetUdpState(bool keepSession) {
     s_udpFirstAudioMs = 0;
     s_udpStartedMs = millis();
     s_udpLastPacketMs = 0;
+    s_udpLastSample = 0;
+    s_udpConcealedPrev = true;
     if (!keepSession) {
         s_udpActive = false;
         s_udpSession = "";
@@ -328,6 +369,14 @@ static bool prepareUdpSpeaker() {
 static void finishUdpSession(const char* reason, bool waitForDrain = true) {
     if (s_udpPlaying) {
         (void)waitForDrain;
+        // Fade the last played sample down to silence instead of cutting
+        // the amplifier off mid-waveform, to avoid an end-of-session click.
+        if (s_udpI2sRunning && s_udpLastSample != 0) {
+            uint8_t fadeFrame[PCM_UDP_FRAME_BYTES];
+            fillConcealmentRamp(fadeFrame, s_udpLastSample);
+            writeUdpI2sFrame(fadeFrame);
+            s_udpLastSample = 0;
+        }
         stopUdpI2s();
         audioGateLeave("pcm-udp");
         requestMicResume();
@@ -493,16 +542,34 @@ static void pumpUdpPlayback() {
     for (uint32_t i = 0; i < PCM_UDP_SLAB_FRAMES; ++i) {
         uint32_t seq = s_udpNextPlaySeq++;
         uint8_t frame[PCM_UDP_FRAME_BYTES];
+        bool gotFrame = false;
         if (s_udpEnding && seq >= s_udpEndSeq) {
-            memset(frame, 0, PCM_UDP_FRAME_BYTES);
-        } else if (!takeUdpFrame(seq, frame)) {
+            // Trailing padding frame(s) past the announced end sequence:
+            // ramp to silence rather than jump straight to a flat zero.
+            fillConcealmentRamp(frame, s_udpLastSample);
+            s_udpConcealedPrev = true;
+        } else if (takeUdpFrame(seq, frame)) {
+            gotFrame = true;
+        } else {
             s_udpFramesLost++;
             s_udpUnderruns++;
+            // Conceal the loss/underrun with a ramp to silence instead of
+            // a hard drop to zero (takeUdpFrame() already zeroed `frame`,
+            // this overwrites it with the ramp).
+            fillConcealmentRamp(frame, s_udpLastSample);
+            s_udpConcealedPrev = true;
+        }
+        if (gotFrame && s_udpConcealedPrev) {
+            // Real audio resuming after concealment (or session start):
+            // fade in instead of jumping straight to full amplitude.
+            applyFadeIn(frame);
+            s_udpConcealedPrev = false;
         }
         if (!writeUdpI2sFrame(frame)) {
             finishUdpSession("i2s-write-failed");
             return;
         }
+        s_udpLastSample = ((const int16_t*)frame)[PCM_UDP_FRAME_SAMPLES - 1];
     }
 }
 

--- a/firmware/src/pcm_stream_service.cpp
+++ b/firmware/src/pcm_stream_service.cpp
@@ -1,0 +1,865 @@
+#include "pcm_stream_service.h"
+
+#include <M5Unified.h>
+#include <WiFi.h>
+#include <WiFiUdp.h>
+#include <driver/i2s.h>
+#include <queue>
+
+#include "audio_gate.h"
+#include "config_loader.h"
+#include "face_service.h"
+#include "playback_service.h"
+
+#define PCM_STREAM_PORT              9090
+#define PCM_UDP_PORT                 9091
+#define PCM_STREAM_SAMPLE_RATE       24000
+#define PCM_STREAM_BYTES_PER_SAMPLE  2
+#define PCM_UDP_FRAME_MS             10
+#define PCM_UDP_FRAME_SAMPLES        ((PCM_STREAM_SAMPLE_RATE * PCM_UDP_FRAME_MS) / 1000)
+#define PCM_UDP_FRAME_BYTES          (PCM_UDP_FRAME_SAMPLES * PCM_STREAM_BYTES_PER_SAMPLE)
+#define PCM_UDP_SLAB_FRAMES          1
+#define PCM_UDP_START_FRAMES         12
+#define PCM_UDP_RING_FRAMES          512
+#define PCM_UDP_HEADER_BYTES         24
+#define PCM_UDP_PACKET_MAX           (PCM_UDP_HEADER_BYTES + PCM_UDP_FRAME_BYTES)
+#define PCM_UDP_VERSION              1
+#define PCM_UDP_FLAG_END             0x01
+#define PCM_UDP_ACTIVE_TIMEOUT_MS    30000
+#define PCM_UDP_PREROLL_TIMEOUT_MS   5000
+#define PCM_UDP_IDLE_END_GRACE_MS    500
+#define PCM_STREAM_SLAB_BYTES        PCM_UDP_FRAME_BYTES
+#define PCM_STREAM_PREBUFFER_BYTES   (PCM_UDP_FRAME_BYTES * 12)
+#define PCM_STREAM_MAX_BUFFERED      (512 * 1024)
+#define PCM_STREAM_MAX_TOTAL         (2 * 1024 * 1024)
+#define PCM_STREAM_CHANNEL           0
+#define PCM_STREAM_HEADER_MAX        160
+#define PCM_STREAM_HEADER_TIMEOUT_MS 3000
+#define PCM_STREAM_READ_TIMEOUT_MS   30000
+
+struct StreamSlab {
+    uint8_t* data = nullptr;
+    size_t size = 0;
+};
+
+static WiFiServer s_streamServer(PCM_STREAM_PORT);
+static WiFiUDP s_udpServer;
+static TaskHandle_t s_streamTask = nullptr;
+static bool s_udpI2sRunning = false;
+static volatile bool s_active = false;
+static volatile bool s_playing = false;
+static volatile bool s_clientConnected = false;
+static String s_session = "";
+static size_t s_bufferedBytes = 0;
+static size_t s_totalBytes = 0;
+static uint32_t s_underruns = 0;
+
+struct UdpFrameSlot {
+    bool valid = false;
+    uint32_t seq = 0;
+    uint8_t data[PCM_UDP_FRAME_BYTES];
+};
+
+static UdpFrameSlot* s_udpRing = nullptr;
+static std::queue<StreamSlab> s_udpSubmitted;
+static volatile bool s_udpActive = false;
+static volatile bool s_udpPlaying = false;
+static bool s_udpEnding = false;
+static bool s_udpReceivedAny = false;
+static String s_udpSession = "";
+static uint32_t s_udpToken = 0;
+static uint32_t s_udpFirstSeq = 0;
+static uint32_t s_udpNextPlaySeq = 0;
+static uint32_t s_udpHighestSeq = 0;
+static uint32_t s_udpEndSeq = 0;
+static uint32_t s_udpFramesReceived = 0;
+static uint32_t s_udpFramesLost = 0;
+static uint32_t s_udpFramesLate = 0;
+static uint32_t s_udpUnderruns = 0;
+static uint32_t s_udpFirstAudioMs = 0;
+static unsigned long s_udpStartedMs = 0;
+static unsigned long s_udpLastPacketMs = 0;
+static String s_udpLastEndReason = "";
+static uint32_t s_udpLastFramesReceived = 0;
+static uint32_t s_udpLastFramesLost = 0;
+static uint32_t s_udpLastFramesLate = 0;
+static uint32_t s_udpLastUnderruns = 0;
+static uint32_t s_udpLastFirstAudioMs = 0;
+
+static constexpr uint8_t CORE_S3_AW88298_I2C_ADDR = 0x36;
+static constexpr uint8_t CORE_S3_AW9523_I2C_ADDR = 0x58;
+static constexpr gpio_num_t CORE_S3_SPK_BCLK = GPIO_NUM_34;
+static constexpr gpio_num_t CORE_S3_SPK_WS = GPIO_NUM_33;
+static constexpr gpio_num_t CORE_S3_SPK_DOUT = GPIO_NUM_13;
+static constexpr i2s_port_t CORE_S3_SPK_I2S_PORT = I2S_NUM_1;
+static constexpr uint32_t PCM_I2S_SAMPLE_RATE = PCM_STREAM_SAMPLE_RATE;
+
+static void handleUdpPackets();
+
+static uint16_t readLe16(const uint8_t* data) {
+    return (uint16_t)data[0] | ((uint16_t)data[1] << 8);
+}
+
+static uint32_t readLe32(const uint8_t* data) {
+    return (uint32_t)data[0] |
+           ((uint32_t)data[1] << 8) |
+           ((uint32_t)data[2] << 16) |
+           ((uint32_t)data[3] << 24);
+}
+
+static void freeSlab(StreamSlab slab) {
+    if (slab.data) {
+        free(slab.data);
+    }
+}
+
+static void freeQueue(std::queue<StreamSlab>& queue) {
+    while (!queue.empty()) {
+        freeSlab(queue.front());
+        queue.pop();
+    }
+}
+
+static size_t udpBufferedFrames() {
+    if (!s_udpRing) {
+        return 0;
+    }
+    size_t count = 0;
+    for (size_t i = 0; i < PCM_UDP_RING_FRAMES; ++i) {
+        if (s_udpRing[i].valid) {
+            count++;
+        }
+    }
+    return count;
+}
+
+static void clearUdpRing() {
+    if (!s_udpRing) {
+        return;
+    }
+    for (size_t i = 0; i < PCM_UDP_RING_FRAMES; ++i) {
+        s_udpRing[i].valid = false;
+        s_udpRing[i].seq = 0;
+    }
+}
+
+static void clearUdpSubmitted() {
+    freeQueue(s_udpSubmitted);
+}
+
+static void aw88298WriteReg(uint8_t reg, uint16_t value) {
+    M5.In_I2C.writeRegister(CORE_S3_AW88298_I2C_ADDR, reg, (const uint8_t*)&value, 2, 400000);
+}
+
+static void setCoreS3AmpEnabled(bool enabled) {
+    if (enabled) {
+        M5.In_I2C.bitOn(CORE_S3_AW9523_I2C_ADDR, 0x02, 0b00000100, 400000);
+        static constexpr uint8_t rateTable[] = {4, 5, 6, 8, 10, 11, 15, 20, 22, 44};
+        size_t reg0x06Value = 0;
+        size_t rate = (PCM_I2S_SAMPLE_RATE + 1102) / 2205;
+        while (rate > rateTable[reg0x06Value] && ++reg0x06Value < sizeof(rateTable)) {}
+        reg0x06Value |= 0x14C0;
+        aw88298WriteReg(0x61, 0x0673);
+        aw88298WriteReg(0x04, 0x4040);
+        aw88298WriteReg(0x05, 0x0008);
+        aw88298WriteReg(0x06, reg0x06Value);
+        aw88298WriteReg(0x0C, 0x0064);
+    } else {
+        aw88298WriteReg(0x04, 0x4000);
+        M5.In_I2C.bitOff(CORE_S3_AW9523_I2C_ADDR, 0x02, 0b00000100, 400000);
+    }
+}
+
+static void stopUdpI2s() {
+    if (s_udpI2sRunning) {
+        i2s_zero_dma_buffer(CORE_S3_SPK_I2S_PORT);
+        i2s_stop(CORE_S3_SPK_I2S_PORT);
+        i2s_driver_uninstall(CORE_S3_SPK_I2S_PORT);
+        s_udpI2sRunning = false;
+    }
+    setCoreS3AmpEnabled(false);
+}
+
+static bool startUdpI2s() {
+    if (s_udpI2sRunning) {
+        return true;
+    }
+    if (M5.Speaker.isRunning()) {
+        M5.Speaker.end();
+        vTaskDelay(pdMS_TO_TICKS(50));
+    }
+
+    i2s_driver_uninstall(CORE_S3_SPK_I2S_PORT);
+    i2s_config_t i2sCfg;
+    memset(&i2sCfg, 0, sizeof(i2sCfg));
+    i2sCfg.mode = (i2s_mode_t)(I2S_MODE_MASTER | I2S_MODE_TX);
+    i2sCfg.sample_rate = PCM_I2S_SAMPLE_RATE;
+    i2sCfg.bits_per_sample = I2S_BITS_PER_SAMPLE_16BIT;
+    i2sCfg.channel_format = I2S_CHANNEL_FMT_RIGHT_LEFT;
+    i2sCfg.communication_format = I2S_COMM_FORMAT_STAND_I2S;
+    i2sCfg.intr_alloc_flags = ESP_INTR_FLAG_LEVEL1;
+    i2sCfg.dma_buf_count = 8;
+    i2sCfg.dma_buf_len = 240;
+    i2sCfg.use_apll = false;
+    i2sCfg.tx_desc_auto_clear = true;
+    i2sCfg.fixed_mclk = 0;
+    esp_err_t err = i2s_driver_install(CORE_S3_SPK_I2S_PORT, &i2sCfg, 0, nullptr);
+    if (err != ESP_OK) {
+        Serial.printf("[PCM/UDP] i2s_driver_install failed: %d\n", (int)err);
+        return false;
+    }
+
+    i2s_pin_config_t pinCfg;
+    memset(&pinCfg, ~0u, sizeof(pinCfg));
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 1)
+    pinCfg.mck_io_num = I2S_PIN_NO_CHANGE;
+#else
+    pinCfg.mck_io_num = I2S_PIN_NO_CHANGE;
+#endif
+    pinCfg.bck_io_num = CORE_S3_SPK_BCLK;
+    pinCfg.ws_io_num = CORE_S3_SPK_WS;
+    pinCfg.data_out_num = CORE_S3_SPK_DOUT;
+    pinCfg.data_in_num = I2S_PIN_NO_CHANGE;
+    err = i2s_set_pin(CORE_S3_SPK_I2S_PORT, &pinCfg);
+    if (err != ESP_OK) {
+        Serial.printf("[PCM/UDP] i2s_set_pin failed: %d\n", (int)err);
+        i2s_driver_uninstall(CORE_S3_SPK_I2S_PORT);
+        return false;
+    }
+    err = i2s_start(CORE_S3_SPK_I2S_PORT);
+    if (err != ESP_OK) {
+        Serial.printf("[PCM/UDP] i2s_start failed: %d\n", (int)err);
+        i2s_driver_uninstall(CORE_S3_SPK_I2S_PORT);
+        return false;
+    }
+    s_udpI2sRunning = true;
+    setCoreS3AmpEnabled(true);
+    return true;
+}
+
+static bool writeUdpI2sFrame(const uint8_t* frame) {
+    if (!s_udpI2sRunning) {
+        return false;
+    }
+    int16_t out[PCM_UDP_FRAME_SAMPLES * 2];
+    const int16_t* in = (const int16_t*)frame;
+    for (size_t i = 0; i < PCM_UDP_FRAME_SAMPLES; ++i) {
+        int16_t sample = in[i];
+        out[i * 2] = sample;
+        out[i * 2 + 1] = sample;
+    }
+    size_t offset = 0;
+    uint8_t* bytes = (uint8_t*)out;
+    size_t byteCount = sizeof(out);
+    while (offset < byteCount) {
+        size_t written = 0;
+        esp_err_t err = i2s_write(CORE_S3_SPK_I2S_PORT, bytes + offset, byteCount - offset, &written, 0);
+        if (err != ESP_OK) {
+            return false;
+        }
+        offset += written;
+        if (offset < byteCount) {
+            handleUdpPackets();
+            vTaskDelay(pdMS_TO_TICKS(1));
+        }
+    }
+    return true;
+}
+
+static bool writePcmI2s(const uint8_t* data, size_t size) {
+    uint8_t frame[PCM_UDP_FRAME_BYTES];
+    size_t offset = 0;
+    while (offset < size) {
+        size_t chunk = min((size_t)PCM_UDP_FRAME_BYTES, size - offset);
+        memcpy(frame, data + offset, chunk);
+        if (chunk < PCM_UDP_FRAME_BYTES) {
+            memset(frame + chunk, 0, PCM_UDP_FRAME_BYTES - chunk);
+        }
+        if (!writeUdpI2sFrame(frame)) {
+            return false;
+        }
+        offset += chunk;
+    }
+    return true;
+}
+
+static void resetUdpState(bool keepSession) {
+    clearUdpRing();
+    clearUdpSubmitted();
+    s_udpPlaying = false;
+    s_udpEnding = false;
+    s_udpReceivedAny = false;
+    s_udpFirstSeq = 0;
+    s_udpNextPlaySeq = 0;
+    s_udpHighestSeq = 0;
+    s_udpEndSeq = 0;
+    s_udpFramesReceived = 0;
+    s_udpFramesLost = 0;
+    s_udpFramesLate = 0;
+    s_udpUnderruns = 0;
+    s_udpFirstAudioMs = 0;
+    s_udpStartedMs = millis();
+    s_udpLastPacketMs = 0;
+    if (!keepSession) {
+        s_udpActive = false;
+        s_udpSession = "";
+        s_udpToken = 0;
+    }
+}
+
+static bool prepareUdpSpeaker() {
+    if (!audioGateEnter("pcm-udp", 1000)) {
+        Serial.println("[PCM/UDP] Audio gate busy");
+        return false;
+    }
+    if (M5.Mic.isRunning()) {
+        M5.Mic.end();
+        vTaskDelay(pdMS_TO_TICKS(200));
+    }
+    if (!startUdpI2s()) {
+        audioGateLeave("pcm-udp");
+        Serial.println("[PCM/UDP] I2S start failed");
+        return false;
+    }
+    setFaceExpression(FACE_PLAYING);
+    return true;
+}
+
+static void finishUdpSession(const char* reason, bool waitForDrain = true) {
+    if (s_udpPlaying) {
+        (void)waitForDrain;
+        stopUdpI2s();
+        audioGateLeave("pcm-udp");
+        requestMicResume();
+    }
+    Serial.printf("[PCM/UDP] complete: session=%s reason=%s frames=%u lost=%u late=%u underruns=%u\n",
+                  s_udpSession.c_str(), reason, (unsigned)s_udpFramesReceived,
+                  (unsigned)s_udpFramesLost, (unsigned)s_udpFramesLate,
+                  (unsigned)s_udpUnderruns);
+    s_udpLastEndReason = reason;
+    s_udpLastFramesReceived = s_udpFramesReceived;
+    s_udpLastFramesLost = s_udpFramesLost;
+    s_udpLastFramesLate = s_udpFramesLate;
+    s_udpLastUnderruns = s_udpUnderruns;
+    s_udpLastFirstAudioMs = s_udpFirstAudioMs;
+    resetUdpState(false);
+    setMouthOpen(0.0f);
+    setFaceExpression(FACE_IDLE);
+}
+
+static bool takeUdpFrame(uint32_t seq, uint8_t* out) {
+    if (!s_udpRing) {
+        memset(out, 0, PCM_UDP_FRAME_BYTES);
+        return false;
+    }
+    UdpFrameSlot& slot = s_udpRing[seq % PCM_UDP_RING_FRAMES];
+    if (!slot.valid || slot.seq != seq) {
+        memset(out, 0, PCM_UDP_FRAME_BYTES);
+        return false;
+    }
+    memcpy(out, slot.data, PCM_UDP_FRAME_BYTES);
+    slot.valid = false;
+    return true;
+}
+
+static bool hasUdpFrame(uint32_t seq) {
+    if (!s_udpRing) {
+        return false;
+    }
+    UdpFrameSlot& slot = s_udpRing[seq % PCM_UDP_RING_FRAMES];
+    return slot.valid && slot.seq == seq;
+}
+
+static void handleUdpPackets() {
+    for (;;) {
+        int packetSize = s_udpServer.parsePacket();
+        if (packetSize <= 0) {
+            return;
+        }
+        uint8_t packet[PCM_UDP_PACKET_MAX];
+        int readSize = s_udpServer.read(packet, min(packetSize, (int)sizeof(packet)));
+        if (!s_udpActive || readSize < PCM_UDP_HEADER_BYTES) {
+            continue;
+        }
+        if (memcmp(packet, "SCP1", 4) != 0 || packet[4] != PCM_UDP_VERSION) {
+            continue;
+        }
+        uint8_t flags = packet[5];
+        uint16_t headerBytes = readLe16(packet + 6);
+        uint32_t token = readLe32(packet + 8);
+        uint32_t seq = readLe32(packet + 12);
+        uint16_t payloadBytes = readLe16(packet + 20);
+        if (headerBytes != PCM_UDP_HEADER_BYTES || token != s_udpToken) {
+            continue;
+        }
+
+        s_udpLastPacketMs = millis();
+        if (flags & PCM_UDP_FLAG_END) {
+            s_udpEnding = true;
+            s_udpEndSeq = seq;
+            continue;
+        }
+        if (payloadBytes != PCM_UDP_FRAME_BYTES ||
+            readSize < (int)(PCM_UDP_HEADER_BYTES + PCM_UDP_FRAME_BYTES)) {
+            continue;
+        }
+        if (s_udpReceivedAny && seq < s_udpNextPlaySeq) {
+            s_udpFramesLate++;
+            continue;
+        }
+
+        if (!s_udpRing) {
+            continue;
+        }
+        UdpFrameSlot& slot = s_udpRing[seq % PCM_UDP_RING_FRAMES];
+        if (slot.valid && slot.seq == seq) {
+            continue;
+        }
+        slot.seq = seq;
+        memcpy(slot.data, packet + PCM_UDP_HEADER_BYTES, PCM_UDP_FRAME_BYTES);
+        slot.valid = true;
+        s_udpFramesReceived++;
+        if (!s_udpReceivedAny) {
+            s_udpReceivedAny = true;
+            s_udpFirstSeq = seq;
+            s_udpNextPlaySeq = seq;
+            s_udpHighestSeq = seq;
+        } else if (seq > s_udpHighestSeq) {
+            s_udpHighestSeq = seq;
+        }
+    }
+}
+
+static void pumpUdpPlayback() {
+    if (!s_udpActive) {
+        return;
+    }
+    unsigned long now = millis();
+    if (!s_udpReceivedAny) {
+        if (now - s_udpStartedMs > PCM_UDP_PREROLL_TIMEOUT_MS) {
+            finishUdpSession("preroll-timeout");
+        }
+        return;
+    }
+    if (!s_udpPlaying) {
+        if (udpBufferedFrames() < PCM_UDP_START_FRAMES && !s_udpEnding) {
+            return;
+        }
+        if (!prepareUdpSpeaker()) {
+            finishUdpSession("speaker-failed");
+            return;
+        }
+        s_udpPlaying = true;
+        s_udpFirstAudioMs = millis() - s_udpStartedMs;
+        Serial.printf("[PCM/UDP] started: session=%s first_audio_ms=%u\n",
+                      s_udpSession.c_str(), (unsigned)s_udpFirstAudioMs);
+    }
+
+    if (s_udpEnding && s_udpNextPlaySeq >= s_udpEndSeq) {
+        finishUdpSession("end");
+        return;
+    }
+    if (!s_udpEnding && now - s_udpLastPacketMs > PCM_UDP_ACTIVE_TIMEOUT_MS) {
+        finishUdpSession("timeout");
+        return;
+    }
+    if (!s_udpEnding && now - s_udpLastPacketMs > PCM_UDP_IDLE_END_GRACE_MS) {
+        if (udpBufferedFrames() == 0) {
+            finishUdpSession("idle", false);
+        } else {
+            s_udpEnding = true;
+            s_udpEndSeq = s_udpHighestSeq + 1;
+        }
+        return;
+    }
+    bool enough = true;
+    for (uint32_t i = 0; i < PCM_UDP_SLAB_FRAMES; ++i) {
+        uint32_t seq = s_udpNextPlaySeq + i;
+        if (s_udpEnding && seq >= s_udpEndSeq) {
+            break;
+        }
+        if (!hasUdpFrame(seq)) {
+            enough = false;
+            break;
+        }
+    }
+    if (!enough && !s_udpEnding && s_udpNextPlaySeq > s_udpHighestSeq) {
+        return;
+    }
+    if (!s_udpEnding && s_udpNextPlaySeq + PCM_UDP_SLAB_FRAMES > s_udpHighestSeq + 1) {
+        return;
+    }
+
+    for (uint32_t i = 0; i < PCM_UDP_SLAB_FRAMES; ++i) {
+        uint32_t seq = s_udpNextPlaySeq++;
+        uint8_t frame[PCM_UDP_FRAME_BYTES];
+        if (s_udpEnding && seq >= s_udpEndSeq) {
+            memset(frame, 0, PCM_UDP_FRAME_BYTES);
+        } else if (!takeUdpFrame(seq, frame)) {
+            s_udpFramesLost++;
+            s_udpUnderruns++;
+        }
+        if (!writeUdpI2sFrame(frame)) {
+            finishUdpSession("i2s-write-failed");
+            return;
+        }
+    }
+}
+
+static bool readHeaderLine(WiFiClient& client, String& line) {
+    const unsigned long deadline = millis() + PCM_STREAM_HEADER_TIMEOUT_MS;
+    line = "";
+    while (millis() < deadline && client.connected()) {
+        while (client.available() > 0) {
+            int value = client.read();
+            if (value < 0) {
+                break;
+            }
+            if (value == '\n') {
+                return true;
+            }
+            if (line.length() >= PCM_STREAM_HEADER_MAX) {
+                return false;
+            }
+            if (value != '\r') {
+                line += (char)value;
+            }
+        }
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+    return false;
+}
+
+static String headerValue(const String& line, const char* key) {
+    String prefix = String(key) + "=";
+    int start = line.indexOf(prefix);
+    if (start < 0) {
+        return "";
+    }
+    start += prefix.length();
+    int end = line.indexOf(' ', start);
+    if (end < 0) {
+        end = line.length();
+    }
+    return line.substring(start, end);
+}
+
+static bool validateHeader(const String& line, String& session, String& error) {
+    if (!line.startsWith("STACKCHAN_PCM_STREAM/1 ")) {
+        error = "ERR PROTOCOL\n";
+        return false;
+    }
+    session = headerValue(line, "session");
+    if (session.length() == 0 || session.length() > 64) {
+        error = "ERR SESSION\n";
+        return false;
+    }
+    if (headerValue(line, "rate") != "24000" ||
+        headerValue(line, "channels") != "1" ||
+        headerValue(line, "width") != "2") {
+        error = "ERR FORMAT\n";
+        return false;
+    }
+    return true;
+}
+
+static bool prepareStreamSpeaker() {
+    if (!audioGateEnter("pcm-stream", 1000)) {
+        Serial.println("[PCM/TCP] Audio gate busy");
+        return false;
+    }
+    if (M5.Mic.isRunning()) {
+        M5.Mic.end();
+        vTaskDelay(pdMS_TO_TICKS(200));
+    }
+    if (!startUdpI2s()) {
+        audioGateLeave("pcm-stream");
+        Serial.println("[PCM/TCP] I2S start failed");
+        return false;
+    }
+    setFaceExpression(FACE_PLAYING);
+    return true;
+}
+
+static void endStreamSpeaker() {
+    stopUdpI2s();
+    setMouthOpen(0.0f);
+    setFaceExpression(FACE_IDLE);
+    audioGateLeave("pcm-stream");
+    requestMicResume();
+}
+
+static StreamSlab readSlab(WiFiClient& client, bool& eof, bool& invalid) {
+    StreamSlab slab;
+    eof = false;
+    invalid = false;
+    uint8_t* data = (uint8_t*)ps_malloc(PCM_STREAM_SLAB_BYTES);
+    if (!data) {
+        invalid = true;
+        Serial.println("[PCM/TCP] slab allocation failed");
+        return slab;
+    }
+
+    const unsigned long deadline = millis() + PCM_STREAM_READ_TIMEOUT_MS;
+    size_t size = 0;
+    while (size < PCM_STREAM_SLAB_BYTES) {
+        int available = client.available();
+        if (available > 0) {
+            int want = min((int)(PCM_STREAM_SLAB_BYTES - size), available);
+            int got = client.read(data + size, want);
+            if (got > 0) {
+                size += got;
+                continue;
+            }
+        }
+        if (!client.connected()) {
+            eof = true;
+            break;
+        }
+        if (millis() > deadline) {
+            invalid = true;
+            Serial.println("[PCM/TCP] read timeout");
+            break;
+        }
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+
+    if (size == 0) {
+        free(data);
+        return slab;
+    }
+    if ((size % PCM_STREAM_BYTES_PER_SAMPLE) != 0) {
+        free(data);
+        invalid = true;
+        Serial.printf("[PCM/TCP] invalid slab size: %u\n", (unsigned)size);
+        return slab;
+    }
+    slab.data = data;
+    slab.size = size;
+    return slab;
+}
+
+static bool readOneQueuedSlab(
+    WiFiClient& client,
+    std::queue<StreamSlab>& pending,
+    bool& eof
+) {
+    bool invalid = false;
+    StreamSlab slab = readSlab(client, eof, invalid);
+    if (invalid) {
+        return false;
+    }
+    if (!slab.data) {
+        return true;
+    }
+    if (s_totalBytes > PCM_STREAM_MAX_TOTAL - slab.size ||
+        s_bufferedBytes > PCM_STREAM_MAX_BUFFERED - slab.size) {
+        Serial.println("[PCM/TCP] stream too large");
+        freeSlab(slab);
+        return false;
+    }
+    pending.push(slab);
+    s_bufferedBytes += slab.size;
+    s_totalBytes += slab.size;
+    return true;
+}
+
+static void playQueuedStream(WiFiClient& client, const String& session) {
+    std::queue<StreamSlab> pending;
+    std::queue<StreamSlab> submitted;
+    bool eof = false;
+
+    while (!eof && s_bufferedBytes < PCM_STREAM_PREBUFFER_BYTES) {
+        if (!readOneQueuedSlab(client, pending, eof)) {
+            freeQueue(pending);
+            return;
+        }
+    }
+    if (pending.empty()) {
+        Serial.println("[PCM/TCP] empty stream");
+        return;
+    }
+    if (!prepareStreamSpeaker()) {
+        freeQueue(pending);
+        return;
+    }
+
+    s_playing = true;
+    Serial.printf("[PCM/TCP] started: session=%s prebuffer=%u\n",
+                  session.c_str(), (unsigned)s_bufferedBytes);
+
+    while (!pending.empty() || !eof) {
+        if (pending.empty()) {
+            s_underruns++;
+            if (!readOneQueuedSlab(client, pending, eof)) {
+                break;
+            }
+            continue;
+        }
+
+        StreamSlab slab = pending.front();
+        pending.pop();
+        s_bufferedBytes -= slab.size;
+        if (!writePcmI2s(slab.data, slab.size)) {
+            Serial.println("[PCM/TCP] I2S write failed");
+            freeSlab(slab);
+            break;
+        }
+        submitted.push(slab);
+        while (submitted.size() > 2) {
+            freeSlab(submitted.front());
+            submitted.pop();
+        }
+        if (!eof && s_bufferedBytes < PCM_STREAM_PREBUFFER_BYTES) {
+            if (!readOneQueuedSlab(client, pending, eof)) {
+                break;
+            }
+        }
+    }
+
+    freeQueue(pending);
+    endStreamSpeaker();
+    freeQueue(submitted);
+    s_playing = false;
+    Serial.printf("[PCM/TCP] complete: session=%s bytes=%u underruns=%u\n",
+                  session.c_str(), (unsigned)s_totalBytes, (unsigned)s_underruns);
+}
+
+static void handleStreamClient(WiFiClient client) {
+    String line;
+    String session;
+    String error;
+
+    s_clientConnected = true;
+    if (!readHeaderLine(client, line) || !validateHeader(line, session, error)) {
+        client.print(error.length() ? error : "ERR HEADER\n");
+        client.stop();
+        s_clientConnected = false;
+        return;
+    }
+    if (s_active || s_udpActive || isPlaybackActive() || M5.Speaker.isPlaying()) {
+        client.print("ERR BUSY\n");
+        client.stop();
+        s_clientConnected = false;
+        return;
+    }
+
+    s_active = true;
+    s_session = session;
+    s_bufferedBytes = 0;
+    s_totalBytes = 0;
+    s_underruns = 0;
+    client.print("OK\n");
+    playQueuedStream(client, session);
+    client.stop();
+    s_session = "";
+    s_active = false;
+    s_clientConnected = false;
+}
+
+static void pcmStreamTask(void*) {
+    s_streamServer.begin();
+    s_udpServer.begin(PCM_UDP_PORT);
+    Serial.printf("[PCM/TCP] Listening on port %u\n", PCM_STREAM_PORT);
+    Serial.printf("[PCM/UDP] Listening on port %u\n", PCM_UDP_PORT);
+    for (;;) {
+        WiFiClient client = s_streamServer.available();
+        if (client) {
+            handleStreamClient(client);
+        }
+        handleUdpPackets();
+        pumpUdpPlayback();
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
+}
+
+void initPcmStreamService() {
+    if (s_streamTask) {
+        return;
+    }
+    xTaskCreatePinnedToCore(
+        pcmStreamTask,
+        "pcmStream",
+        8192,
+        nullptr,
+        1,
+        &s_streamTask,
+        1
+    );
+}
+
+bool isPcmStreamActive() {
+    return s_active || s_playing || s_udpActive || s_udpPlaying;
+}
+
+UdpPcmSessionResult beginUdpPcmSession() {
+    UdpPcmSessionResult result;
+    result.port = PCM_UDP_PORT;
+    if (!s_udpRing) {
+        s_udpRing = (UdpFrameSlot*)ps_malloc(sizeof(UdpFrameSlot) * PCM_UDP_RING_FRAMES);
+        if (!s_udpRing) {
+            result.error = "alloc failed";
+            return result;
+        }
+        memset(s_udpRing, 0, sizeof(UdpFrameSlot) * PCM_UDP_RING_FRAMES);
+    }
+    if (s_active || s_playing || s_udpActive || s_udpPlaying || isPlaybackActive() || M5.Speaker.isPlaying()) {
+        result.error = "busy";
+        return result;
+    }
+    resetUdpState(false);
+    s_udpActive = true;
+    s_udpToken = esp_random();
+    if (s_udpToken == 0) {
+        s_udpToken = 1;
+    }
+    s_udpSession = String("udp_") + String(s_udpToken, HEX) + String("_") + String(millis(), HEX);
+    s_udpStartedMs = millis();
+    result.success = true;
+    result.session = s_udpSession;
+    result.token = s_udpToken;
+    Serial.printf("[PCM/UDP] session started: session=%s token=%08x\n",
+                  s_udpSession.c_str(), (unsigned)s_udpToken);
+    return result;
+}
+
+bool stopUdpPcmSession(const String& sessionId) {
+    if (!s_udpActive || (sessionId.length() > 0 && sessionId != s_udpSession)) {
+        return false;
+    }
+    finishUdpSession("stopped");
+    return true;
+}
+
+PcmStreamStatus getPcmStreamStatus() {
+    PcmStreamStatus status;
+    status.enabled = s_streamTask != nullptr;
+    status.active = s_active;
+    status.playing = s_playing;
+    status.clientConnected = s_clientConnected;
+    status.session = s_session.c_str();
+    status.port = PCM_STREAM_PORT;
+    status.bufferedBytes = s_bufferedBytes;
+    status.totalBytes = s_totalBytes;
+    status.underruns = s_underruns;
+    status.udpEnabled = s_streamTask != nullptr;
+    status.udpActive = s_udpActive;
+    status.udpPlaying = s_udpPlaying;
+    status.udpSession = s_udpSession.c_str();
+    status.udpPort = PCM_UDP_PORT;
+    status.udpToken = s_udpToken;
+    status.udpBufferedFrames = udpBufferedFrames();
+    status.udpBufferedBytes = status.udpBufferedFrames * PCM_UDP_FRAME_BYTES;
+    status.udpFramesReceived = s_udpFramesReceived;
+    status.udpFramesLost = s_udpFramesLost;
+    status.udpFramesLate = s_udpFramesLate;
+    status.udpUnderruns = s_udpUnderruns;
+    status.udpFirstAudioMs = s_udpFirstAudioMs;
+    status.udpLastEndReason = s_udpLastEndReason.c_str();
+    status.udpLastFramesReceived = s_udpLastFramesReceived;
+    status.udpLastFramesLost = s_udpLastFramesLost;
+    status.udpLastFramesLate = s_udpLastFramesLate;
+    status.udpLastUnderruns = s_udpLastUnderruns;
+    status.udpLastFirstAudioMs = s_udpLastFirstAudioMs;
+    return status;
+}

--- a/firmware/src/pcm_stream_service.h
+++ b/firmware/src/pcm_stream_service.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <Arduino.h>
+
+struct PcmStreamStatus {
+    bool enabled = false;
+    bool active = false;
+    bool playing = false;
+    bool clientConnected = false;
+    const char* session = "";
+    uint16_t port = 9090;
+    size_t bufferedBytes = 0;
+    size_t totalBytes = 0;
+    uint32_t underruns = 0;
+    bool udpEnabled = false;
+    bool udpActive = false;
+    bool udpPlaying = false;
+    const char* udpSession = "";
+    uint16_t udpPort = 9091;
+    uint32_t udpToken = 0;
+    size_t udpBufferedFrames = 0;
+    size_t udpBufferedBytes = 0;
+    uint32_t udpFramesReceived = 0;
+    uint32_t udpFramesLost = 0;
+    uint32_t udpFramesLate = 0;
+    uint32_t udpUnderruns = 0;
+    uint32_t udpFirstAudioMs = 0;
+    const char* udpLastEndReason = "";
+    uint32_t udpLastFramesReceived = 0;
+    uint32_t udpLastFramesLost = 0;
+    uint32_t udpLastFramesLate = 0;
+    uint32_t udpLastUnderruns = 0;
+    uint32_t udpLastFirstAudioMs = 0;
+};
+
+struct UdpPcmSessionResult {
+    bool success = false;
+    String session = "";
+    uint32_t token = 0;
+    uint16_t port = 9091;
+    const char* error = "";
+};
+
+void initPcmStreamService();
+bool isPcmStreamActive();
+UdpPcmSessionResult beginUdpPcmSession();
+bool stopUdpPcmSession(const String& sessionId);
+PcmStreamStatus getPcmStreamStatus();

--- a/firmware/src/pcm_stream_service.h
+++ b/firmware/src/pcm_stream_service.h
@@ -2,6 +2,9 @@
 
 #include <Arduino.h>
 
+#define PCM_UDP_FRAME_MS     10
+#define PCM_UDP_START_FRAMES 12
+
 struct PcmStreamStatus {
     bool enabled = false;
     bool active = false;

--- a/firmware/src/playback_service.cpp
+++ b/firmware/src/playback_service.cpp
@@ -7,6 +7,7 @@
 #include "face_service.h"
 #include "wav_parser.h"
 #include "audio_gate.h"
+#include "pcm_stream_service.h"
 
 struct PlaybackRuntimeState {
     size_t lipSyncOffset = 0;
@@ -63,11 +64,17 @@ static size_t s_pcmQueuedBytes = 0;
 static QueueHandle_t s_downloadCompleteQueue = nullptr;
 static bool s_downloadInFlight = false;
 static unsigned long s_lastSpeakerEndMs = 0;
+static uint8_t* s_stagedPcmData = nullptr;
+static size_t s_stagedPcmSize = 0;
+static size_t s_stagedPcmCapacity = 0;
+static String s_stagedPcmSessionId = "";
+static long s_stagedPcmNextSeq = 0;
 
 static void processAudioQueue();
+static void clearStagedPcmPlayback();
 
 static bool hasPendingPlaybackWork() {
-    return s_downloadInFlight || !s_audioQueue.empty() || !s_pcmQueue.empty();
+    return s_downloadInFlight || !s_audioQueue.empty() || !s_pcmQueue.empty() || isPcmStreamActive();
 }
 
 void clearQueuedPcmPlayback() {
@@ -77,7 +84,51 @@ void clearQueuedPcmPlayback() {
         free(dropped.data);
     }
     s_pcmQueuedBytes = 0;
+    clearStagedPcmPlayback();
     Serial.println("[PCM] Queue cleared");
+}
+
+static void clearStagedPcmPlayback() {
+    if (s_stagedPcmData) {
+        free(s_stagedPcmData);
+    }
+    s_stagedPcmData = nullptr;
+    s_stagedPcmSize = 0;
+    s_stagedPcmCapacity = 0;
+    s_stagedPcmSessionId = "";
+    s_stagedPcmNextSeq = 0;
+}
+
+static bool reserveStagedPcm(size_t requiredSize) {
+    if (requiredSize <= s_stagedPcmCapacity) {
+        return true;
+    }
+
+    size_t newCapacity = s_stagedPcmCapacity ? s_stagedPcmCapacity : (128 * 1024);
+    while (newCapacity < requiredSize) {
+        if (newCapacity > MAX_PCM_BYTES / 2) {
+            newCapacity = MAX_PCM_BYTES;
+            break;
+        }
+        newCapacity *= 2;
+    }
+    if (newCapacity < requiredSize || newCapacity > MAX_PCM_BYTES) {
+        return false;
+    }
+
+    uint8_t* newData = (uint8_t*)ps_malloc(newCapacity);
+    if (!newData) {
+        return false;
+    }
+    if (s_stagedPcmData && s_stagedPcmSize > 0) {
+        memcpy(newData, s_stagedPcmData, s_stagedPcmSize);
+    }
+    if (s_stagedPcmData) {
+        free(s_stagedPcmData);
+    }
+    s_stagedPcmData = newData;
+    s_stagedPcmCapacity = newCapacity;
+    return true;
 }
 
 static bool enqueuePcmBuffer(uint8_t* pcmData, size_t pcmSize, const String& sessionId, bool finalSegment) {
@@ -326,7 +377,7 @@ PcmPlaybackResult startPcmPlayback(uint8_t* pcmData, size_t pcmSize, const Strin
         Serial.printf("[PCM] Invalid size: %u\n", (unsigned)pcmSize);
         return PCM_PLAYBACK_INVALID;
     }
-    if (s_isPlaying || M5.Speaker.isPlaying()) {
+    if (s_isPlaying || isPcmStreamActive() || M5.Speaker.isPlaying()) {
         if (s_playbackState.currentIsPcm && sessionId == s_playbackState.pcmSessionId &&
             enqueuePcmBuffer(pcmData, pcmSize, sessionId, finalSegment)) {
             return PCM_PLAYBACK_QUEUED;
@@ -408,6 +459,78 @@ PcmPlaybackResult startPcmPlayback(uint8_t* pcmData, size_t pcmSize, const Strin
     logAudioMemory("pcm-start");
     audioGateLeave("pcm-play");
     return PCM_PLAYBACK_OK;
+}
+
+PcmPlaybackResult stagePcmPlayback(uint8_t* pcmData, size_t pcmSize, const String& sessionId, long seq, bool finalSegment) {
+    if (!pcmData || pcmSize == 0) {
+        Serial.println("[PCM] Empty staged segment");
+        return PCM_PLAYBACK_INVALID;
+    }
+    if (sessionId.length() == 0 || seq < 0) {
+        Serial.println("[PCM] Invalid staged metadata");
+        return PCM_PLAYBACK_INVALID;
+    }
+    if ((pcmSize % PCM_BYTES_PER_SAMPLE) != 0 || pcmSize > MAX_PCM_BYTES) {
+        Serial.printf("[PCM] Invalid staged size: %u\n", (unsigned)pcmSize);
+        return PCM_PLAYBACK_INVALID;
+    }
+    if (s_isPlaying || isPcmStreamActive() || M5.Speaker.isPlaying() || s_downloadInFlight ||
+        !s_audioQueue.empty() || !s_pcmQueue.empty()) {
+        Serial.printf("[PCM] Busy; refusing staged segment session=%s\n", sessionId.c_str());
+        return PCM_PLAYBACK_BUSY;
+    }
+
+    const bool newSession = sessionId != s_stagedPcmSessionId;
+    if (newSession) {
+        if (seq != 0) {
+            Serial.printf("[PCM] Staged seq mismatch for new session: got=%ld expected=0\n", seq);
+            return PCM_PLAYBACK_SESSION_MISMATCH;
+        }
+        clearStagedPcmPlayback();
+        s_stagedPcmSessionId = sessionId;
+    } else if (seq != s_stagedPcmNextSeq) {
+        Serial.printf("[PCM] Staged seq mismatch: session=%s got=%ld expected=%ld\n",
+                      sessionId.c_str(), seq, s_stagedPcmNextSeq);
+        return PCM_PLAYBACK_SESSION_MISMATCH;
+    }
+
+    if (pcmSize > MAX_PCM_BYTES - s_stagedPcmSize) {
+        Serial.printf("[PCM] Staged payload too large: current=%u segment=%u\n",
+                      (unsigned)s_stagedPcmSize, (unsigned)pcmSize);
+        clearStagedPcmPlayback();
+        return PCM_PLAYBACK_INVALID;
+    }
+    const size_t newSize = s_stagedPcmSize + pcmSize;
+    if (!reserveStagedPcm(newSize)) {
+        Serial.printf("[PCM] Staged alloc failed: required=%u\n", (unsigned)newSize);
+        clearStagedPcmPlayback();
+        free(pcmData);
+        return PCM_PLAYBACK_SPEAKER_FAILED;
+    }
+
+    memcpy(s_stagedPcmData + s_stagedPcmSize, pcmData, pcmSize);
+    s_stagedPcmSize = newSize;
+    s_stagedPcmNextSeq = seq + 1;
+    free(pcmData);
+
+    Serial.printf("[PCM] Staged segment: session=%s seq=%ld bytes=%u total=%u final=%s\n",
+                  sessionId.c_str(), seq, (unsigned)pcmSize, (unsigned)s_stagedPcmSize,
+                  finalSegment ? "true" : "false");
+
+    if (!finalSegment) {
+        return PCM_PLAYBACK_QUEUED;
+    }
+
+    uint8_t* stagedData = s_stagedPcmData;
+    size_t stagedSize = s_stagedPcmSize;
+    String stagedSession = s_stagedPcmSessionId;
+    s_stagedPcmData = nullptr;
+    s_stagedPcmSize = 0;
+    s_stagedPcmCapacity = 0;
+    s_stagedPcmSessionId = "";
+    s_stagedPcmNextSeq = 0;
+
+    return startPcmPlayback(stagedData, stagedSize, stagedSession, true);
 }
 
 // ════════════════════════════════════════
@@ -520,7 +643,7 @@ static void processAudioQueue() {
 bool enqueueAudioTask(const AudioTask& task) {
     AudioTask queuedTask = task;
     queuedTask.sequence = s_nextAudioSequence++;
-    if (s_isPlaying || s_downloadInFlight) {
+    if (s_isPlaying || s_downloadInFlight || isPcmStreamActive()) {
         if (s_audioQueue.size() >= MAX_AUDIO_QUEUE_DEPTH) {
             Serial.printf("[PLAY] Audio queue full; dropped: %s\n", queuedTask.voice_url.c_str());
             return false;
@@ -583,4 +706,8 @@ bool shouldResumeMic() {
 
 void clearMicResumeRequest() {
     s_micResumeRequested = false;
+}
+
+void requestMicResume() {
+    s_micResumeRequested = true;
 }

--- a/firmware/src/playback_service.h
+++ b/firmware/src/playback_service.h
@@ -6,6 +6,7 @@ void updatePlayback();
 bool isPlaybackActive();
 bool shouldResumeMic();
 void clearMicResumeRequest();
+void requestMicResume();
 bool enqueueAudioTask(const AudioTask& task);
 enum PcmPlaybackResult {
     PCM_PLAYBACK_OK,
@@ -31,5 +32,6 @@ struct PlaybackStatus {
     unsigned long deadlineMs = 0;
 };
 PcmPlaybackResult startPcmPlayback(uint8_t* pcmData, size_t pcmSize, const String& sessionId, bool finalSegment);
+PcmPlaybackResult stagePcmPlayback(uint8_t* pcmData, size_t pcmSize, const String& sessionId, long seq, bool finalSegment);
 void clearQueuedPcmPlayback();
 PlaybackStatus getPlaybackStatus();

--- a/mcp_server/mcp_tools.py
+++ b/mcp_server/mcp_tools.py
@@ -9,7 +9,13 @@ import requests
 from . import audio_processing
 from .audio_server import AUDIO_DIR, audio_url, start_audio_server
 from .listening import capture_ready_recording, format_listen_result
-from .stackchan_client import PcmPlaybackError, StackchanClient, post_pcm_stream
+from .stackchan_client import (
+    PcmPlaybackError,
+    StackchanClient,
+    post_pcm_stream,
+    post_pcm_tcp_stream,
+    post_pcm_udp_stream,
+)
 from .stackchan_config import VALID_FACES, StackchanConfig, config_summary
 from .telemetry import emit_event, new_request_id
 from .voice_inbox import clear_events, format_events, read_events
@@ -35,6 +41,12 @@ def format_timing_ms(timings: dict[str, object]) -> str:
         if value is not None:
             parts.append(f"{key}={value}ms")
     return " timing[" + " ".join(parts) + "]" if parts else ""
+
+
+def format_speech_confirmation(text: str) -> str:
+    preview = text[:60]
+    suffix = "…" if len(text) > 60 else ""
+    return f"🗣️ Stack-chan is saying: \"{preview}{suffix}\""
 
 
 def check_audio_dir() -> dict[str, object]:
@@ -76,6 +88,31 @@ def build_health_report(client: StackchanClient, config: StackchanConfig) -> dic
     return report
 
 
+def post_preferred_pcm_stream(client: StackchanClient, text: str, lang: str, config: StackchanConfig) -> dict:
+    def pcm_chunks():
+        return audio_processing.iter_fish_pcm_stream(text, lang, config)
+
+    if config.pcm_transport == "staged":
+        result = post_pcm_stream(client, pcm_chunks(), AUDIO_DIR, audio_processing)
+        result.setdefault("transport", "staged")
+        return result
+
+    if config.pcm_transport in {"auto", "tcp"}:
+        try:
+            return post_pcm_tcp_stream(client, pcm_chunks(), AUDIO_DIR, audio_processing)
+        except PcmPlaybackError as exc:
+            if exc.started or config.pcm_transport == "tcp":
+                raise
+            logger.warning("Falling back from TCP PCM to staged PCM: %s", exc)
+
+    if config.pcm_transport == "udp":
+        return post_pcm_udp_stream(client, pcm_chunks(), AUDIO_DIR, audio_processing)
+
+    result = post_pcm_stream(client, pcm_chunks(), AUDIO_DIR, audio_processing)
+    result.setdefault("transport", "staged")
+    return result
+
+
 def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_cls):
     @mcp.tool()
     def stackchan_say(text: str, lang: str = "zh") -> str:
@@ -88,14 +125,10 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
             if can_stream_pcm(config):
                 pcm_started = time.perf_counter()
                 try:
-                    result = post_pcm_stream(
-                        client,
-                        audio_processing.iter_fish_pcm_stream(text, lang, config),
-                        AUDIO_DIR,
-                        audio_processing,
-                    )
+                    result = post_preferred_pcm_stream(client, text, lang, config)
                     if result.get("success"):
                         diag = (
+                            f" transport={result.get('transport', 'staged')}"
                             f" session={result.get('session', '?')}"
                             f" segments={result.get('segments', '?')}"
                             f" bytes={result.get('total_bytes', '?')}"
@@ -112,6 +145,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
                             attributes={
                                 "stackchan.audio.path": "pcm",
                                 "stackchan.audio.mode": config.audio_mode,
+                                "stackchan.pcm.transport": result.get("transport", "staged"),
                                 "stackchan.tts.engine": config.tts_engine,
                                 "stackchan.lang": lang,
                                 "stackchan.text.length": len(text),
@@ -122,10 +156,8 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
                         )
                         if result.get("saved_pcm"):
                             diag += f" saved={result['saved_pcm']}"
-                        return (
-                            f"🗣️ Stack-chan is saying: \"{text[:60]}{'…' if len(text)>60 else ''}\" "
-                            f"[Fish Audio PCM/{lang}{diag}{format_timing_ms(timings)}]"
-                        )
+                        logger.info("PCM speech accepted: lang=%s%s%s", lang, diag, format_timing_ms(timings))
+                        return format_speech_confirmation(text)
                     pcm_fallback_reason = f"PCM play returned {result}"
                     if config.audio_mode == "pcm":
                         return f"❌ PCM play failed: {result}"
@@ -217,11 +249,15 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
                         **{f"stackchan.latency.{key}_ms": value for key, value in wav_timing.items()},
                     },
                 )
-                return (
-                    f"🗣️ Stack-chan is saying: \"{text[:60]}{'…' if len(text)>60 else ''}\" "
-                    f"[{engine} WAV/{lang} mode={config.audio_mode}{fallback_note}"
-                    f"{format_timing_ms(wav_timing)}]"
+                logger.info(
+                    "WAV speech accepted: engine=%s lang=%s mode=%s%s%s",
+                    engine,
+                    lang,
+                    config.audio_mode,
+                    fallback_note,
+                    format_timing_ms(wav_timing),
                 )
+                return format_speech_confirmation(text)
             emit_event(
                 "stackchan.say.failed",
                 body="Playback request failed",

--- a/mcp_server/stackchan_client.py
+++ b/mcp_server/stackchan_client.py
@@ -1,3 +1,5 @@
+import socket
+import struct
 import time
 from contextlib import suppress
 
@@ -5,7 +7,10 @@ import requests
 
 from .stackchan_config import (
     PCM_CONTENT_TYPE,
+    PCM_SAMPLE_RATE,
     PCM_SAMPLE_WIDTH,
+    PCM_UDP_FRAME_BYTES,
+    PCM_UDP_FRAME_MS,
     StackchanConfig,
 )
 
@@ -74,6 +79,25 @@ class StackchanClient:
     def playback_status(self) -> dict:
         return requests.get(f"{self.base_url}/playback/status", timeout=self.config.http_status_timeout).json()
 
+    def start_audio_session(self) -> dict:
+        return requests.post(
+            f"{self.base_url}/audio/session",
+            json={
+                "codec": "pcm_s16le",
+                "sample_rate": PCM_SAMPLE_RATE,
+                "channels": 1,
+                "sample_width": PCM_SAMPLE_WIDTH,
+                "frame_ms": PCM_UDP_FRAME_MS,
+            },
+            timeout=self.config.http_command_timeout,
+        ).json()
+
+    def stop_audio_session(self, session_id: str) -> dict:
+        return requests.delete(
+            f"{self.base_url}/audio/session/{session_id}",
+            timeout=self.config.http_command_timeout,
+        ).json()
+
     def move(self, x: float, y: float, speed: int) -> dict:
         return requests.post(
             f"{self.base_url}/move",
@@ -132,7 +156,10 @@ def post_pcm_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_proces
         )
         declicked_samples += declicked
         last_segment_tail_sample = struct.unpack_from("<h", segment, len(segment) - PCM_SAMPLE_WIDTH)[0]
-        url = f"{client.base_url}/play/pcm?session={session_id}&seq={segment_index}&final={1 if final else 0}"
+        url = (
+            f"{client.base_url}/play/pcm?session={session_id}&seq={segment_index}"
+            f"&final={1 if final else 0}&mode=staged"
+        )
         try:
             resp = requests.post(
                 url,
@@ -142,6 +169,7 @@ def post_pcm_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_proces
                     "X-Stackchan-Pcm-Session": session_id,
                     "X-Stackchan-Pcm-Seq": str(segment_index),
                     "X-Stackchan-Pcm-Final": "1" if final else "0",
+                    "X-Stackchan-Pcm-Mode": "staged",
                 },
                 timeout=client.config.pcm_segment_post_timeout,
             )
@@ -160,7 +188,8 @@ def post_pcm_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_proces
 
         if not result.get("success"):
             raise PcmPlaybackError(f"PCM segment play failed: {result}", started=started)
-        started = True
+        if not result.get("staged"):
+            started = True
         if first_segment_ms is None:
             first_segment_ms = round((time.perf_counter() - started_at) * 1000)
         segment_index += 1
@@ -263,4 +292,353 @@ def post_pcm_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_proces
     )
     if saved_pcm_path is not None:
         result.setdefault("saved_pcm", str(saved_pcm_path))
+    return result
+
+
+def post_pcm_tcp_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_processing) -> dict:
+    import uuid
+
+    started_at = time.perf_counter()
+    session_id = uuid.uuid4().hex
+    first_chunk_ms = None
+    first_send_ms = None
+    total_input_size = 0
+    total_sent_size = 0
+    limited_samples = 0
+    pending_sample_bytes = b""
+    saved_pcm_path = audio_dir / f"diag_{session_id}.pcm" if client.config.save_pcm else None
+    saved_pcm_file = saved_pcm_path.open("wb") if saved_pcm_path is not None else None
+    initial_buffer = bytearray()
+    chunks_iter = iter(pcm_chunks)
+    accepted = False
+    exhausted = False
+
+    def condition_chunk(chunk: bytes) -> bytes:
+        nonlocal first_chunk_ms, limited_samples, pending_sample_bytes, total_input_size
+        if not chunk:
+            return b""
+        if first_chunk_ms is None:
+            first_chunk_ms = round((time.perf_counter() - started_at) * 1000)
+        total_input_size += len(chunk)
+        if total_input_size > client.config.max_pcm_payload_bytes:
+            raise ValueError(
+                f"PCM payload too large: {total_input_size} bytes exceeds "
+                f"{client.config.max_pcm_payload_bytes} byte limit"
+            )
+        if saved_pcm_file is not None:
+            saved_pcm_file.write(chunk)
+        if pending_sample_bytes:
+            chunk = pending_sample_bytes + chunk
+            pending_sample_bytes = b""
+        if len(chunk) % PCM_SAMPLE_WIDTH != 0:
+            pending_sample_bytes = chunk[-(len(chunk) % PCM_SAMPLE_WIDTH) :]
+            chunk = chunk[: -(len(chunk) % PCM_SAMPLE_WIDTH)]
+        if not chunk:
+            return b""
+        conditioned_chunk, limited = audio_processing.condition_pcm_chunk(
+            chunk,
+            gain=client.config.pcm_gain,
+            limit=client.config.pcm_limit,
+        )
+        limited_samples += limited
+        return conditioned_chunk
+
+    def next_conditioned_chunk() -> bytes | None:
+        nonlocal exhausted
+        for chunk in chunks_iter:
+            conditioned = condition_chunk(chunk)
+            if conditioned:
+                return conditioned
+        exhausted = True
+        return None
+
+    try:
+        while len(initial_buffer) < client.config.pcm_stream_initial_buffer_bytes:
+            chunk = next_conditioned_chunk()
+            if chunk is None:
+                break
+            initial_buffer.extend(chunk)
+            elapsed = time.perf_counter() - started_at
+            if client.config.pcm_first_segment_timeout > 0 and elapsed > client.config.pcm_first_segment_timeout:
+                raise ValueError(
+                    "PCM stream initial buffer timeout: "
+                    f"{len(initial_buffer)} bytes buffered in {elapsed:.1f}s"
+                )
+        if exhausted and pending_sample_bytes:
+            raise ValueError(f"invalid PCM payload size: trailing {len(pending_sample_bytes)} byte partial sample")
+        if not initial_buffer:
+            raise ValueError("invalid PCM payload size: 0")
+
+        address = (client.config.stackchan_ip, client.config.pcm_stream_port)
+        header = (
+            f"STACKCHAN_PCM_STREAM/1 session={session_id} rate={PCM_SAMPLE_RATE} "
+            "channels=1 width=2\n"
+        ).encode("ascii")
+        try:
+            with socket.create_connection(address, timeout=client.config.pcm_stream_connect_timeout) as sock:
+                sock.settimeout(client.config.pcm_stream_io_timeout)
+                sock.sendall(header)
+                response = bytearray()
+                while not response.endswith(b"\n") and len(response) < 80:
+                    chunk = sock.recv(1)
+                    if not chunk:
+                        break
+                    response.extend(chunk)
+                if response != b"OK\n":
+                    message = response.decode("ascii", errors="replace").strip() or "no response"
+                    raise PcmPlaybackError(f"PCM TCP stream rejected: {message}", started=False)
+                accepted = True
+
+                sock.sendall(initial_buffer)
+                total_sent_size += len(initial_buffer)
+                first_send_ms = round((time.perf_counter() - started_at) * 1000)
+
+                while True:
+                    chunk = next_conditioned_chunk()
+                    if chunk is None:
+                        break
+                    sock.sendall(chunk)
+                    total_sent_size += len(chunk)
+                if pending_sample_bytes:
+                    raise PcmPlaybackError(
+                        f"invalid PCM payload size: trailing {len(pending_sample_bytes)} byte partial sample",
+                        started=True,
+                    )
+        except PcmPlaybackError:
+            raise
+        except OSError as exc:
+            raise PcmPlaybackError(f"PCM TCP stream failed: {exc}", started=accepted) from exc
+    finally:
+        if saved_pcm_file is not None:
+            saved_pcm_file.close()
+
+    result = {
+        "success": True,
+        "session": session_id,
+        "transport": "tcp",
+        "total_bytes": total_input_size,
+        "sent_bytes": total_sent_size,
+        "pcm_gain": client.config.pcm_gain,
+        "pcm_limit": client.config.pcm_limit,
+        "limited_samples": limited_samples,
+        "timing_ms": {
+            "pcm_total": round((time.perf_counter() - started_at) * 1000),
+            "fish_first_chunk": first_chunk_ms,
+            "first_stream_send": first_send_ms,
+        },
+    }
+    if saved_pcm_path is not None:
+        result["saved_pcm"] = str(saved_pcm_path)
+    return result
+
+
+def status_int(status: dict, *keys: str) -> int:
+    for key in keys:
+        value = status.get(key)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def wait_for_udp_completion_status(client: StackchanClient, session_id: str) -> dict:
+    timeout = min(max(client.config.playback_start_timeout, 0.5), 3.0)
+    interval = max(client.config.playback_poll_interval, 0.05)
+    deadline = time.monotonic() + timeout
+    last_status: dict = {}
+    while time.monotonic() < deadline:
+        try:
+            last_status = client.playback_status()
+        except requests.RequestException:
+            break
+        current_session = str(last_status.get("udp_audio_session") or "")
+        udp_active = bool(last_status.get("udp_audio_active") or last_status.get("udp_audio_playing"))
+        if not udp_active and current_session in {"", session_id}:
+            return last_status
+        time.sleep(interval)
+    return last_status
+
+
+def post_pcm_udp_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_processing) -> dict:
+    import uuid
+
+    started_at = time.perf_counter()
+    diagnostic_id = uuid.uuid4().hex
+    first_chunk_ms = None
+    first_send_ms = None
+    total_input_size = 0
+    total_sent_size = 0
+    limited_samples = 0
+    pending_sample_bytes = b""
+    frame_buffer = bytearray()
+    seq = 0
+    session_id = ""
+    accepted = False
+    saved_pcm_path = audio_dir / f"diag_{diagnostic_id}.pcm" if client.config.save_pcm else None
+    saved_pcm_file = saved_pcm_path.open("wb") if saved_pcm_path is not None else None
+
+    session = client.start_audio_session()
+    if not session.get("success"):
+        raise PcmPlaybackError(f"PCM UDP session failed: {session}", started=False)
+    accepted = True
+    session_id = str(session.get("session", ""))
+    token = int(session.get("token", 0))
+    udp_port = int(session.get("udp_port", 0))
+    if not session_id or token == 0 or udp_port <= 0:
+        raise PcmPlaybackError(f"PCM UDP session returned invalid metadata: {session}", started=False)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.settimeout(client.config.pcm_stream_io_timeout)
+    address = (client.config.stackchan_ip, udp_port)
+    frame_seconds = (PCM_UDP_FRAME_MS / 1000.0) * client.config.udp_pace_factor
+    burst_frames = max(1, int(40 / PCM_UDP_FRAME_MS))
+    pacing_started_at: float | None = None
+    next_send_at: float | None = None
+
+    def send_frame(frame: bytes, *, end: bool = False) -> None:
+        nonlocal first_send_ms, pacing_started_at, next_send_at, seq, total_sent_size
+        now = time.perf_counter()
+        if not end and pacing_started_at is not None and seq >= burst_frames and next_send_at is not None:
+            delay = next_send_at - now
+            if delay > 0:
+                time.sleep(delay)
+                now = time.perf_counter()
+        flags = 1 if end else 0
+        payload = b"" if end else frame
+        header = struct.pack(
+            "<4sBBHIIIHH",
+            b"SCP1",
+            1,
+            flags,
+            24,
+            token,
+            seq,
+            seq * (PCM_SAMPLE_RATE * PCM_UDP_FRAME_MS // 1000),
+            len(payload),
+            0,
+        )
+        packet = header + payload
+        sock.sendto(packet, address)
+        if not end:
+            total_sent_size += len(payload)
+            if first_send_ms is None:
+                first_send_ms = round((time.perf_counter() - started_at) * 1000)
+                pacing_started_at = time.perf_counter()
+                next_send_at = pacing_started_at
+            seq += 1
+            if pacing_started_at is not None and seq >= burst_frames:
+                base = max(now, next_send_at or now)
+                next_send_at = base + frame_seconds
+
+    def condition_chunk(chunk: bytes) -> bytes:
+        nonlocal first_chunk_ms, limited_samples, pending_sample_bytes, total_input_size
+        if not chunk:
+            return b""
+        if first_chunk_ms is None:
+            first_chunk_ms = round((time.perf_counter() - started_at) * 1000)
+        total_input_size += len(chunk)
+        if total_input_size > client.config.max_pcm_payload_bytes:
+            raise PcmPlaybackError(
+                f"PCM payload too large: {total_input_size} bytes exceeds "
+                f"{client.config.max_pcm_payload_bytes} byte limit",
+                started=accepted,
+            )
+        if saved_pcm_file is not None:
+            saved_pcm_file.write(chunk)
+        if pending_sample_bytes:
+            chunk = pending_sample_bytes + chunk
+            pending_sample_bytes = b""
+        if len(chunk) % PCM_SAMPLE_WIDTH != 0:
+            pending_sample_bytes = chunk[-(len(chunk) % PCM_SAMPLE_WIDTH) :]
+            chunk = chunk[: -(len(chunk) % PCM_SAMPLE_WIDTH)]
+        if not chunk:
+            return b""
+        conditioned_chunk, limited = audio_processing.condition_pcm_chunk(
+            chunk,
+            gain=client.config.pcm_gain,
+            limit=client.config.pcm_limit,
+        )
+        limited_samples += limited
+        return conditioned_chunk
+
+    try:
+        for chunk in pcm_chunks:
+            conditioned = condition_chunk(chunk)
+            if not conditioned:
+                continue
+            frame_buffer.extend(conditioned)
+            elapsed = time.perf_counter() - started_at
+            if first_send_ms is None and client.config.pcm_first_segment_timeout > 0 and elapsed > client.config.pcm_first_segment_timeout:
+                raise ValueError(
+                    "PCM UDP first frame timeout: "
+                    f"{len(frame_buffer)} bytes buffered in {elapsed:.1f}s"
+                )
+            while len(frame_buffer) >= PCM_UDP_FRAME_BYTES:
+                send_frame(bytes(frame_buffer[:PCM_UDP_FRAME_BYTES]))
+                del frame_buffer[:PCM_UDP_FRAME_BYTES]
+        if pending_sample_bytes:
+            raise PcmPlaybackError(
+                f"invalid PCM payload size: trailing {len(pending_sample_bytes)} byte partial sample",
+                started=accepted,
+            )
+        if frame_buffer:
+            frame_buffer.extend(b"\x00" * (PCM_UDP_FRAME_BYTES - len(frame_buffer)))
+            send_frame(bytes(frame_buffer))
+        if seq == 0:
+            raise ValueError("invalid PCM payload size: 0")
+        for _ in range(3):
+            send_frame(b"", end=True)
+            time.sleep(0.005)
+    except OSError as exc:
+        raise PcmPlaybackError(f"PCM UDP stream failed: {exc}", started=accepted) from exc
+    finally:
+        sock.close()
+        if saved_pcm_file is not None:
+            saved_pcm_file.close()
+
+    completion_status = wait_for_udp_completion_status(client, session_id)
+    frames_received = status_int(completion_status, "udp_last_frames_received", "frames_received")
+    frames_lost = status_int(completion_status, "udp_last_frames_lost", "frames_lost")
+    underruns = status_int(completion_status, "udp_last_underruns", "underruns")
+    end_reason = str(completion_status.get("udp_last_end_reason") or "")
+
+    result = {
+        "success": True,
+        "session": session_id,
+        "transport": "udp",
+        "frames": seq,
+        "segments": seq,
+        "total_bytes": total_input_size,
+        "sent_bytes": total_sent_size,
+        "pcm_gain": client.config.pcm_gain,
+        "pcm_limit": client.config.pcm_limit,
+        "limited_samples": limited_samples,
+        "timing_ms": {
+            "pcm_total": round((time.perf_counter() - started_at) * 1000),
+            "fish_first_chunk": first_chunk_ms,
+            "first_udp_frame": first_send_ms,
+        },
+        "udp_pace_factor": client.config.udp_pace_factor,
+        "udp_frames_received": frames_received,
+        "udp_frames_lost": frames_lost,
+        "udp_underruns": underruns,
+        "udp_end_reason": end_reason,
+    }
+    if saved_pcm_path is not None:
+        result["saved_pcm"] = str(saved_pcm_path)
+    if completion_status and (
+        frames_lost > 0
+        or underruns > 0
+        or (frames_received > 0 and frames_received < seq)
+        or (end_reason and end_reason != "end")
+    ):
+        raise PcmPlaybackError(
+            "PCM UDP playback incomplete: "
+            f"sent_frames={seq} received={frames_received} "
+            f"lost={frames_lost} underruns={underruns} reason={end_reason or '?'}",
+            started=True,
+        )
     return result

--- a/mcp_server/stackchan_client.py
+++ b/mcp_server/stackchan_client.py
@@ -114,6 +114,7 @@ def post_pcm_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_proces
     first_chunk_ms = None
     first_segment_ms = None
     pending_segment = None
+    pending_sample_bytes = b""
     limited_samples = 0
     declicked_samples = 0
     last_segment_tail_sample = None
@@ -182,6 +183,24 @@ def post_pcm_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_proces
                 raise ValueError(message)
             if saved_pcm_file is not None:
                 saved_pcm_file.write(chunk)
+            if pending_sample_bytes:
+                chunk = pending_sample_bytes + chunk
+                pending_sample_bytes = b""
+            if len(chunk) % PCM_SAMPLE_WIDTH != 0:
+                pending_sample_bytes = chunk[-(len(chunk) % PCM_SAMPLE_WIDTH) :]
+                chunk = chunk[: -(len(chunk) % PCM_SAMPLE_WIDTH)]
+            if not chunk:
+                continue
+            elapsed = time.perf_counter() - started_at
+            if (
+                not started
+                and client.config.pcm_first_segment_timeout > 0
+                and elapsed > client.config.pcm_first_segment_timeout
+            ):
+                raise ValueError(
+                    "PCM first segment timeout: "
+                    f"{len(buffer) + len(chunk)} bytes buffered in {elapsed:.1f}s"
+                )
             conditioned_chunk, limited = audio_processing.condition_pcm_chunk(
                 chunk,
                 gain=client.config.pcm_gain,
@@ -205,6 +224,11 @@ def post_pcm_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_proces
 
         if not buffer and pending_segment is None and last_result is None:
             raise ValueError("invalid PCM payload size: 0")
+        if pending_sample_bytes:
+            message = f"invalid PCM payload size: trailing {len(pending_sample_bytes)} byte partial sample"
+            if started:
+                raise PcmPlaybackError(message, started=True)
+            raise ValueError(message)
         if len(buffer) % PCM_SAMPLE_WIDTH != 0:
             message = f"invalid PCM payload size: {len(buffer)}"
             if started:

--- a/mcp_server/stackchan_client.py
+++ b/mcp_server/stackchan_client.py
@@ -445,7 +445,9 @@ def status_int(status: dict, *keys: str) -> int:
 
 
 def wait_for_udp_completion_status(client: StackchanClient, session_id: str) -> dict:
-    timeout = min(max(client.config.playback_start_timeout, 0.5), 3.0)
+    # Firmware's preroll-failure timer is PCM_UDP_PREROLL_TIMEOUT_MS (5s); the poll window
+    # must outlive it or we give up before the device reports a real completion status.
+    timeout = max(client.config.playback_start_timeout, 6.0)
     interval = max(client.config.playback_poll_interval, 0.05)
     deadline = time.monotonic() + timeout
     last_status: dict = {}
@@ -462,6 +464,25 @@ def wait_for_udp_completion_status(client: StackchanClient, session_id: str) -> 
     return last_status
 
 
+def _fade_pcm_tail_to_silence(buffer: bytearray, real_len: int, samples: int) -> int:
+    """Ramp the last `samples` samples of the real (pre-padding) audio in `buffer` toward
+    silence, mirroring the weighting used by audio_processing.declick_pcm_segment but applied
+    at the tail instead of the head (that helper only smooths a segment's leading edge)."""
+    if samples <= 0 or real_len <= 0:
+        return 0
+    sample_count = real_len // PCM_SAMPLE_WIDTH
+    ramp = min(samples, sample_count)
+    if ramp <= 0:
+        return 0
+    start_sample = sample_count - ramp
+    for offset in range(ramp):
+        pos = (start_sample + offset) * PCM_SAMPLE_WIDTH
+        current = struct.unpack_from("<h", buffer, pos)[0]
+        weight = (ramp - offset) / (ramp + 1)
+        struct.pack_into("<h", buffer, pos, round(current * weight))
+    return ramp
+
+
 def post_pcm_udp_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_processing) -> dict:
     import uuid
 
@@ -472,6 +493,7 @@ def post_pcm_udp_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_pr
     total_input_size = 0
     total_sent_size = 0
     limited_samples = 0
+    declicked_samples = 0
     pending_sample_bytes = b""
     frame_buffer = bytearray()
     seq = 0
@@ -495,6 +517,9 @@ def post_pcm_udp_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_pr
     address = (client.config.stackchan_ip, udp_port)
     frame_seconds = (PCM_UDP_FRAME_MS / 1000.0) * client.config.udp_pace_factor
     burst_frames = max(1, int(40 / PCM_UDP_FRAME_MS))
+    # Firmware's UDP ring holds 512 frames; never schedule further ahead of wall clock than
+    # this, or a post-stall catch-up burst could overwrite slots the device hasn't played yet.
+    max_lead_seconds = 256 * frame_seconds
     pacing_started_at: float | None = None
     next_send_at: float | None = None
 
@@ -530,8 +555,14 @@ def post_pcm_udp_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_pr
                 next_send_at = pacing_started_at
             seq += 1
             if pacing_started_at is not None and seq >= burst_frames:
-                base = max(now, next_send_at or now)
+                # Cumulative schedule: never rebase to "now". Rebasing after a stall (the old
+                # `max(now, ...)` behavior) silently discards the lost time and drains the
+                # device's buffer instead of sending a catch-up burst to refill it.
+                base = next_send_at if next_send_at is not None else now
                 next_send_at = base + frame_seconds
+                lead = next_send_at - time.perf_counter()
+                if lead > max_lead_seconds:
+                    time.sleep(lead - max_lead_seconds)
 
     def condition_chunk(chunk: bytes) -> bytes:
         nonlocal first_chunk_ms, limited_samples, pending_sample_bytes, total_input_size
@@ -577,15 +608,31 @@ def post_pcm_udp_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_pr
                     f"{len(frame_buffer)} bytes buffered in {elapsed:.1f}s"
                 )
             while len(frame_buffer) >= PCM_UDP_FRAME_BYTES:
-                send_frame(bytes(frame_buffer[:PCM_UDP_FRAME_BYTES]))
+                frame = bytes(frame_buffer[:PCM_UDP_FRAME_BYTES])
                 del frame_buffer[:PCM_UDP_FRAME_BYTES]
+                if seq == 0:
+                    frame, faded_in = audio_processing.declick_pcm_segment(
+                        frame, 0, client.config.pcm_declick_samples
+                    )
+                    declicked_samples += faded_in
+                send_frame(frame)
         if pending_sample_bytes:
             raise PcmPlaybackError(
                 f"invalid PCM payload size: trailing {len(pending_sample_bytes)} byte partial sample",
                 started=accepted,
             )
         if frame_buffer:
-            frame_buffer.extend(b"\x00" * (PCM_UDP_FRAME_BYTES - len(frame_buffer)))
+            real_len = len(frame_buffer)
+            frame_buffer.extend(b"\x00" * (PCM_UDP_FRAME_BYTES - real_len))
+            if seq == 0:
+                padded, faded_in = audio_processing.declick_pcm_segment(
+                    bytes(frame_buffer), 0, client.config.pcm_declick_samples
+                )
+                declicked_samples += faded_in
+                frame_buffer[:] = padded
+            declicked_samples += _fade_pcm_tail_to_silence(
+                frame_buffer, real_len, client.config.pcm_declick_samples
+            )
             send_frame(bytes(frame_buffer))
         if seq == 0:
             raise ValueError("invalid PCM payload size: 0")
@@ -616,6 +663,7 @@ def post_pcm_udp_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_pr
         "pcm_gain": client.config.pcm_gain,
         "pcm_limit": client.config.pcm_limit,
         "limited_samples": limited_samples,
+        "declicked_samples": declicked_samples,
         "timing_ms": {
             "pcm_total": round((time.perf_counter() - started_at) * 1000),
             "fish_first_chunk": first_chunk_ms,
@@ -629,7 +677,24 @@ def post_pcm_udp_stream(client: StackchanClient, pcm_chunks, audio_dir, audio_pr
     }
     if saved_pcm_path is not None:
         result["saved_pcm"] = str(saved_pcm_path)
-    if completion_status and (
+    # A totally missing status (device unreachable) is distinct from a status that reports
+    # zero frames received, so check it first and fail loudly rather than assume success.
+    if not completion_status:
+        raise PcmPlaybackError(
+            "PCM UDP playback could not be verified: no completion status from device "
+            f"(sent_frames={seq}, session={session_id})",
+            started=True,
+        )
+    # This dominates whatever else the status reports: a completion status -- even a stale
+    # one left over from a previous session -- can never mask the device having received
+    # nothing at all for this session.
+    if seq > 0 and frames_received == 0:
+        raise PcmPlaybackError(
+            "PCM UDP playback incomplete: device received no frames "
+            f"(sent_frames={seq}, session={session_id})",
+            started=True,
+        )
+    if (
         frames_lost > 0
         or underruns > 0
         or (frames_received > 0 and frames_received < seq)

--- a/mcp_server/stackchan_config.py
+++ b/mcp_server/stackchan_config.py
@@ -91,10 +91,16 @@ class StackchanConfig:
     audio_serve_port: int
     tts_engine: str
     audio_mode: str
+    pcm_transport: str
     save_pcm: bool
     pcm_gain: float
     pcm_limit: float
     pcm_segment_bytes: int
+    pcm_stream_port: int
+    pcm_stream_initial_buffer_bytes: int
+    pcm_stream_connect_timeout: float
+    pcm_stream_io_timeout: float
+    udp_pace_factor: float
     max_pcm_payload_bytes: int
     pcm_declick_samples: int
     pcm_zero_cross_window: int
@@ -118,12 +124,18 @@ class StackchanConfig:
 
 
 VALID_AUDIO_MODES = {"auto", "pcm", "wav"}
+VALID_PCM_TRANSPORTS = {"auto", "udp", "tcp", "staged"}
 PCM_SAMPLE_RATE = 24000
 PCM_CHANNELS = 1
 PCM_SAMPLE_WIDTH = 2
 PCM_CONTENT_TYPE = "audio/x-raw;format=s16le;rate=24000;channels=1"
 MAX_PCM_PAYLOAD_BYTES = 2 * 1024 * 1024
 PCM_SEGMENT_BYTES = 48 * 1024
+PCM_STREAM_PORT = 9090
+PCM_UDP_PORT = 9091
+PCM_UDP_FRAME_MS = 10
+PCM_UDP_FRAME_BYTES = (PCM_SAMPLE_RATE * PCM_UDP_FRAME_MS // 1000) * PCM_SAMPLE_WIDTH
+PCM_STREAM_INITIAL_BUFFER_BYTES = 96 * 1024
 FISH_STREAM_CHUNK_BYTES = 4096
 DEFAULT_AUDIO_DIR = str(Path(tempfile.gettempdir()) / "stackchan_audio")
 VALID_FACES = ("calm", "thinking", "happy", "sleepy", "shy", "smug", "pouty")
@@ -147,16 +159,25 @@ def config_summary(config: StackchanConfig) -> dict[str, Any]:
             "save_pcm": config.save_pcm,
         },
         "pcm": {
+            "transport": config.pcm_transport,
             "sample_rate": PCM_SAMPLE_RATE,
             "channels": PCM_CHANNELS,
             "sample_width": PCM_SAMPLE_WIDTH,
             "segment_bytes": config.pcm_segment_bytes,
+            "stream_port": config.pcm_stream_port,
+            "udp_port": PCM_UDP_PORT,
+            "udp_frame_ms": PCM_UDP_FRAME_MS,
+            "udp_frame_bytes": PCM_UDP_FRAME_BYTES,
+            "udp_pace_factor": config.udp_pace_factor,
+            "stream_initial_buffer_bytes": config.pcm_stream_initial_buffer_bytes,
             "max_payload_bytes": config.max_pcm_payload_bytes,
             "gain": config.pcm_gain,
             "limit": config.pcm_limit,
             "declick_samples": config.pcm_declick_samples,
             "zero_cross_window": config.pcm_zero_cross_window,
             "first_segment_timeout": config.pcm_first_segment_timeout,
+            "stream_connect_timeout": config.pcm_stream_connect_timeout,
+            "stream_io_timeout": config.pcm_stream_io_timeout,
         },
         "tts": {
             "engine": config.tts_engine,
@@ -185,10 +206,14 @@ def config_summary(config: StackchanConfig) -> dict[str, Any]:
 def load_config() -> StackchanConfig:
     load_dotenv()
 
-    audio_mode = os.environ.get("STACKCHAN_AUDIO_MODE", "auto").lower()
+    audio_mode = os.environ.get("STACKCHAN_AUDIO_MODE", "wav").lower()
     if audio_mode not in VALID_AUDIO_MODES:
-        logger.warning("Invalid STACKCHAN_AUDIO_MODE=%s; using auto", audio_mode)
-        audio_mode = "auto"
+        logger.warning("Invalid STACKCHAN_AUDIO_MODE=%s; using wav", audio_mode)
+        audio_mode = "wav"
+    pcm_transport = os.environ.get("STACKCHAN_PCM_TRANSPORT", os.environ.get("STACKCHAN_AUDIO_TRANSPORT", "tcp")).lower()
+    if pcm_transport not in VALID_PCM_TRANSPORTS:
+        logger.warning("Invalid STACKCHAN_PCM_TRANSPORT=%s; using auto", pcm_transport)
+        pcm_transport = "auto"
 
     pcm_segment_bytes = clamp_int(
         env_int("STACKCHAN_PCM_SEGMENT_BYTES", PCM_SEGMENT_BYTES),
@@ -204,7 +229,7 @@ def load_config() -> StackchanConfig:
         pcm_segment_bytes,
         64 * 1024 * 1024,
     )
-    pcm_gain = max(0.0, min(env_float("STACKCHAN_PCM_GAIN", 0.75), 1.0))
+    pcm_gain = max(0.0, min(env_float("STACKCHAN_PCM_GAIN", 1.0), 1.0))
     pcm_limit = max(0.1, min(env_float("STACKCHAN_PCM_LIMIT", 0.90), 1.0))
     pcm_declick_samples = max(
         0,
@@ -222,10 +247,26 @@ def load_config() -> StackchanConfig:
         audio_serve_port=int(os.environ.get("AUDIO_SERVE_PORT", 5060)),
         tts_engine=os.environ.get("TTS_ENGINE", "fish-audio"),
         audio_mode=audio_mode,
+        pcm_transport=pcm_transport,
         save_pcm=env_bool("STACKCHAN_SAVE_PCM"),
         pcm_gain=pcm_gain,
         pcm_limit=pcm_limit,
         pcm_segment_bytes=pcm_segment_bytes,
+        pcm_stream_port=clamp_int(env_int("STACKCHAN_PCM_STREAM_PORT", PCM_STREAM_PORT), 1, 65535),
+        pcm_stream_initial_buffer_bytes=clamp_int(
+            env_int("STACKCHAN_PCM_STREAM_INITIAL_BUFFER_BYTES", PCM_STREAM_INITIAL_BUFFER_BYTES),
+            PCM_SAMPLE_WIDTH,
+            MAX_PCM_PAYLOAD_BYTES,
+        ),
+        pcm_stream_connect_timeout=env_float_any(
+            ("STACKCHAN_PCM_STREAM_CONNECT_TIMEOUT", "STACKCHAN_PCM_STREAM_CONNECT_TIMEOUT_SEC"),
+            3.0,
+        ),
+        pcm_stream_io_timeout=env_float_any(
+            ("STACKCHAN_PCM_STREAM_IO_TIMEOUT", "STACKCHAN_PCM_STREAM_IO_TIMEOUT_SEC"),
+            30.0,
+        ),
+        udp_pace_factor=max(1.0, min(env_float("STACKCHAN_UDP_PACE_FACTOR", 1.0), 1.5)),
         max_pcm_payload_bytes=max_pcm_payload_bytes,
         pcm_declick_samples=pcm_declick_samples,
         pcm_zero_cross_window=pcm_zero_cross_window,

--- a/mcp_server/stackchan_config.py
+++ b/mcp_server/stackchan_config.py
@@ -98,6 +98,7 @@ class StackchanConfig:
     max_pcm_payload_bytes: int
     pcm_declick_samples: int
     pcm_zero_cross_window: int
+    pcm_first_segment_timeout: float
     http_play_timeout: float
     http_audio_timeout: float
     http_status_timeout: float
@@ -155,6 +156,7 @@ def config_summary(config: StackchanConfig) -> dict[str, Any]:
             "limit": config.pcm_limit,
             "declick_samples": config.pcm_declick_samples,
             "zero_cross_window": config.pcm_zero_cross_window,
+            "first_segment_timeout": config.pcm_first_segment_timeout,
         },
         "tts": {
             "engine": config.tts_engine,
@@ -227,6 +229,10 @@ def load_config() -> StackchanConfig:
         max_pcm_payload_bytes=max_pcm_payload_bytes,
         pcm_declick_samples=pcm_declick_samples,
         pcm_zero_cross_window=pcm_zero_cross_window,
+        pcm_first_segment_timeout=env_float_any(
+            ("STACKCHAN_PCM_FIRST_SEGMENT_TIMEOUT", "STACKCHAN_PCM_FIRST_SEGMENT_TIMEOUT_SEC"),
+            3.0,
+        ),
         http_play_timeout=env_float_any(("STACKCHAN_HTTP_PLAY_TIMEOUT", "STACKCHAN_HTTP_PLAY_TIMEOUT_SEC"), 5.0),
         http_audio_timeout=env_float_any(("STACKCHAN_HTTP_AUDIO_TIMEOUT", "STACKCHAN_HTTP_AUDIO_TIMEOUT_SEC"), 10.0),
         http_status_timeout=env_float_any(("STACKCHAN_HTTP_STATUS_TIMEOUT", "STACKCHAN_HTTP_STATUS_TIMEOUT_SEC"), 3.0),

--- a/mcp_server/stackchan_config.py
+++ b/mcp_server/stackchan_config.py
@@ -266,7 +266,7 @@ def load_config() -> StackchanConfig:
             ("STACKCHAN_PCM_STREAM_IO_TIMEOUT", "STACKCHAN_PCM_STREAM_IO_TIMEOUT_SEC"),
             30.0,
         ),
-        udp_pace_factor=max(1.0, min(env_float("STACKCHAN_UDP_PACE_FACTOR", 1.0), 1.5)),
+        udp_pace_factor=max(0.85, min(env_float("STACKCHAN_UDP_PACE_FACTOR", 1.0), 1.5)),
         max_pcm_payload_bytes=max_pcm_payload_bytes,
         pcm_declick_samples=pcm_declick_samples,
         pcm_zero_cross_window=pcm_zero_cross_window,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -83,6 +83,7 @@ def make_config(**overrides):
         "playback_start_timeout": 5.0,
         "playback_poll_interval": 0.2,
         "pcm_segment_post_timeout": 30.0,
+        "pcm_first_segment_timeout": 3.0,
         "fish_tts_timeout": 30.0,
         "fish_asr_timeout": 15.0,
         "fish_stream_chunk_bytes": 4096,
@@ -273,6 +274,7 @@ def test_config_reads_pcm_and_timeout_env_aliases(monkeypatch):
     monkeypatch.setenv("STACKCHAN_PCM_MAX_PAYLOAD_BYTES", "1048576")
     monkeypatch.setenv("STACKCHAN_PLAYBACK_START_TIMEOUT_SEC", "7.5")
     monkeypatch.setenv("STACKCHAN_PCM_SEGMENT_POST_TIMEOUT_SEC", "22")
+    monkeypatch.setenv("STACKCHAN_PCM_FIRST_SEGMENT_TIMEOUT_SEC", "4.5")
     monkeypatch.setenv("STACKCHAN_FISH_STREAM_CHUNK_BYTES", "8192")
 
     config = load_config()
@@ -281,6 +283,7 @@ def test_config_reads_pcm_and_timeout_env_aliases(monkeypatch):
     assert config.max_pcm_payload_bytes == 1048576
     assert config.playback_start_timeout == 7.5
     assert config.pcm_segment_post_timeout == 22
+    assert config.pcm_first_segment_timeout == 4.5
     assert config.fish_stream_chunk_bytes == 8192
 
 
@@ -797,6 +800,34 @@ def test_post_pcm_stream_posts_binary_payload_with_content_length(monkeypatch, t
     assert headers["X-Stackchan-Pcm-Seq"] == "0"
     assert headers["X-Stackchan-Pcm-Final"] == "1"
     assert "final=1" in request_kwargs["args"][0]
+
+
+def test_post_pcm_stream_handles_split_sample_boundaries(monkeypatch, tmp_path):
+    request_kwargs = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"success": True}
+
+    def fake_post(*args, **kwargs):
+        request_kwargs["args"] = args
+        request_kwargs["kwargs"] = kwargs
+        return FakeResponse()
+
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.post", fake_post)
+
+    result = post_pcm_stream(
+        StackchanClient(make_config()),
+        iter([b"\xe8", b"\x03\x18", b"\xfc"]),
+        tmp_path,
+        audio_processing,
+    )
+
+    assert result["success"] is True
+    assert request_kwargs["kwargs"]["data"] == struct.pack("<hh", 750, -750)
 
 
 def test_wait_for_playback_start_detects_started_ms_change(monkeypatch):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import requests
 
 from mcp_server import audio_processing
 from mcp_server.audio_server import audio_url
@@ -339,6 +340,27 @@ def test_invalid_pcm_env_values_fall_back_to_defaults(monkeypatch):
     assert config.pcm_limit == 0.90
     assert config.pcm_declick_samples == 64
     assert config.pcm_zero_cross_window == 256
+
+
+def test_udp_pace_factor_clamps_to_lower_and_upper_bounds(monkeypatch):
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
+
+    monkeypatch.setenv("STACKCHAN_UDP_PACE_FACTOR", "0.5")
+    low_config = load_config()
+
+    monkeypatch.setenv("STACKCHAN_UDP_PACE_FACTOR", "0.85")
+    floor_config = load_config()
+
+    monkeypatch.setenv("STACKCHAN_UDP_PACE_FACTOR", "3.0")
+    high_config = load_config()
+
+    monkeypatch.delenv("STACKCHAN_UDP_PACE_FACTOR", raising=False)
+    default_config = load_config()
+
+    assert low_config.udp_pace_factor == 0.85
+    assert floor_config.udp_pace_factor == 0.85
+    assert high_config.udp_pace_factor == 1.5
+    assert default_config.udp_pace_factor == 1.0
 
 
 def test_invalid_audio_mode_falls_back_to_auto(monkeypatch):
@@ -1264,6 +1286,127 @@ def test_post_pcm_udp_stream_raises_when_device_reports_lost_frames(monkeypatch,
     monkeypatch.setattr("mcp_server.stackchan_client.time.sleep", lambda _seconds: None)
 
     with pytest.raises(PcmPlaybackError, match="lost=1 underruns=1") as excinfo:
+        post_pcm_udp_stream(
+            StackchanClient(make_config(pcm_transport="udp")),
+            iter([b"\x00\x00" * (PCM_UDP_FRAME_BYTES // 2)]),
+            tmp_path,
+            audio_processing,
+        )
+
+    assert excinfo.value.started is True
+
+
+def test_post_pcm_udp_stream_reports_declicked_samples(monkeypatch, tmp_path):
+    class FakeResponse:
+        def json(self):
+            return {"success": True, "session": "udp-test", "token": 0x12345678, "udp_port": 9091}
+
+    class FakeStatusResponse:
+        def json(self):
+            return {
+                "udp_audio_active": False,
+                "udp_audio_playing": False,
+                "udp_audio_session": "",
+                "udp_last_end_reason": "end",
+                "udp_last_frames_received": 1,
+                "udp_last_frames_lost": 0,
+                "udp_last_underruns": 0,
+            }
+
+    class FakeSocket:
+        def settimeout(self, _timeout):
+            return None
+
+        def sendto(self, _data, _address):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.post", lambda *_args, **_kwargs: FakeResponse())
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.get", lambda *_args, **_kwargs: FakeStatusResponse())
+    monkeypatch.setattr("mcp_server.stackchan_client.socket.socket", lambda *_args, **_kwargs: FakeSocket())
+    monkeypatch.setattr("mcp_server.stackchan_client.time.sleep", lambda _seconds: None)
+
+    result = post_pcm_udp_stream(
+        StackchanClient(make_config(pcm_transport="udp")),
+        iter([b"\x00\x00" * (PCM_UDP_FRAME_BYTES // 2)]),
+        tmp_path,
+        audio_processing,
+    )
+
+    # The lone frame is both the session's first and last, so it gets both a fade-in and a
+    # fade-out ramp counted; on all-zero audio the ramp is a no-op but the sample count is real.
+    assert result["declicked_samples"] > 0
+
+
+def test_post_pcm_udp_stream_raises_when_device_receives_zero_frames(monkeypatch, tmp_path):
+    class FakeSessionResponse:
+        def json(self):
+            return {"success": True, "session": "udp-test", "token": 0x12345678, "udp_port": 9091}
+
+    class FakeStatusResponse:
+        def json(self):
+            return {
+                "udp_audio_active": False,
+                "udp_audio_playing": False,
+                "udp_audio_session": "",
+                "udp_last_end_reason": "end",
+                "udp_last_frames_received": 0,
+                "udp_last_frames_lost": 0,
+                "udp_last_underruns": 0,
+            }
+
+    class FakeSocket:
+        def settimeout(self, _timeout):
+            return None
+
+        def sendto(self, _data, _address):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.post", lambda *_args, **_kwargs: FakeSessionResponse())
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.get", lambda *_args, **_kwargs: FakeStatusResponse())
+    monkeypatch.setattr("mcp_server.stackchan_client.socket.socket", lambda *_args, **_kwargs: FakeSocket())
+    monkeypatch.setattr("mcp_server.stackchan_client.time.sleep", lambda _seconds: None)
+
+    with pytest.raises(PcmPlaybackError, match="no frames") as excinfo:
+        post_pcm_udp_stream(
+            StackchanClient(make_config(pcm_transport="udp")),
+            iter([b"\x00\x00" * (PCM_UDP_FRAME_BYTES // 2)]),
+            tmp_path,
+            audio_processing,
+        )
+
+    assert excinfo.value.started is True
+
+
+def test_post_pcm_udp_stream_raises_when_completion_status_unavailable(monkeypatch, tmp_path):
+    class FakeSessionResponse:
+        def json(self):
+            return {"success": True, "session": "udp-test", "token": 0x12345678, "udp_port": 9091}
+
+    class FakeSocket:
+        def settimeout(self, _timeout):
+            return None
+
+        def sendto(self, _data, _address):
+            return None
+
+        def close(self):
+            return None
+
+    def fake_get(*_args, **_kwargs):
+        raise requests.exceptions.ConnectionError("device unreachable")
+
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.post", lambda *_args, **_kwargs: FakeSessionResponse())
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.get", fake_get)
+    monkeypatch.setattr("mcp_server.stackchan_client.socket.socket", lambda *_args, **_kwargs: FakeSocket())
+    monkeypatch.setattr("mcp_server.stackchan_client.time.sleep", lambda _seconds: None)
+
+    with pytest.raises(PcmPlaybackError, match="could not be verified") as excinfo:
         post_pcm_udp_stream(
             StackchanClient(make_config(pcm_transport="udp")),
             iter([b"\x00\x00" * (PCM_UDP_FRAME_BYTES // 2)]),

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -14,11 +14,23 @@ import pytest
 from mcp_server import audio_processing
 from mcp_server.audio_server import audio_url
 from mcp_server.listening import capture_ready_recording, format_listen_result
-from mcp_server.mcp_tools import can_stream_pcm, register_tools
-from mcp_server.stackchan_client import PcmPlaybackError, StackchanClient, post_pcm_stream
+from mcp_server.mcp_tools import (
+    can_stream_pcm,
+    format_speech_confirmation,
+    post_preferred_pcm_stream,
+    register_tools,
+)
+from mcp_server.stackchan_client import (
+    PcmPlaybackError,
+    StackchanClient,
+    post_pcm_stream,
+    post_pcm_tcp_stream,
+    post_pcm_udp_stream,
+)
 from mcp_server.stackchan_config import (
     PCM_SAMPLE_WIDTH,
     PCM_SEGMENT_BYTES,
+    PCM_UDP_FRAME_BYTES,
     StackchanConfig,
     load_config,
 )
@@ -67,10 +79,16 @@ def make_config(**overrides):
         "audio_serve_port": 5099,
         "tts_engine": "fish-audio",
         "audio_mode": "auto",
+        "pcm_transport": "tcp",
         "save_pcm": False,
-        "pcm_gain": 0.75,
+        "pcm_gain": 1.0,
         "pcm_limit": 0.90,
         "pcm_segment_bytes": PCM_SEGMENT_BYTES,
+        "pcm_stream_port": 9090,
+        "pcm_stream_initial_buffer_bytes": 96 * 1024,
+        "pcm_stream_connect_timeout": 3.0,
+        "pcm_stream_io_timeout": 30.0,
+        "udp_pace_factor": 1.0,
         "max_pcm_payload_bytes": 2 * 1024 * 1024,
         "pcm_declick_samples": 64,
         "pcm_zero_cross_window": 256,
@@ -255,7 +273,60 @@ def test_audio_url_uses_configured_host_and_port():
     assert audio_url("192.0.2.10", 5099, "hello.wav") == "http://192.0.2.10:5099/hello.wav"
 
 
+def test_speech_confirmation_omits_transport_diagnostics():
+    result = format_speech_confirmation("你好，小克" * 20)
+
+    assert result.startswith("🗣️ Stack-chan is saying: \"")
+    assert "transport=" not in result
+    assert "timing[" not in result
+    assert "…" in result
+
+
+def test_preferred_pcm_auto_uses_tcp_before_experimental_udp(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_tcp(_client, _chunks, _audio_dir, _audio_processing):
+        calls.append("tcp")
+        return {"success": True, "transport": "tcp", "total_bytes": 2}
+
+    def fake_udp(*_args, **_kwargs):
+        raise AssertionError("auto should not use UDP")
+
+    monkeypatch.setattr("mcp_server.mcp_tools.AUDIO_DIR", tmp_path)
+    monkeypatch.setattr("mcp_server.mcp_tools.post_pcm_tcp_stream", fake_tcp)
+    monkeypatch.setattr("mcp_server.mcp_tools.post_pcm_udp_stream", fake_udp)
+
+    config = make_config(pcm_transport="auto")
+    result = post_preferred_pcm_stream(StackchanClient(config), "hello", "zh", config)
+
+    assert calls == ["tcp"]
+    assert result["transport"] == "tcp"
+
+
+def test_preferred_pcm_auto_falls_back_to_staged_when_tcp_rejects_before_start(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_tcp(_client, _chunks, _audio_dir, _audio_processing):
+        calls.append("tcp")
+        raise PcmPlaybackError("busy", started=False)
+
+    def fake_staged(_client, _chunks, _audio_dir, _audio_processing):
+        calls.append("staged")
+        return {"success": True, "total_bytes": 2}
+
+    monkeypatch.setattr("mcp_server.mcp_tools.AUDIO_DIR", tmp_path)
+    monkeypatch.setattr("mcp_server.mcp_tools.post_pcm_tcp_stream", fake_tcp)
+    monkeypatch.setattr("mcp_server.mcp_tools.post_pcm_stream", fake_staged)
+
+    config = make_config(pcm_transport="auto")
+    result = post_preferred_pcm_stream(StackchanClient(config), "hello", "zh", config)
+
+    assert calls == ["tcp", "staged"]
+    assert result["transport"] == "staged"
+
+
 def test_invalid_pcm_env_values_fall_back_to_defaults(monkeypatch):
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
     monkeypatch.setenv("STACKCHAN_PCM_GAIN", "loud")
     monkeypatch.setenv("STACKCHAN_PCM_LIMIT", "hot")
     monkeypatch.setenv("STACKCHAN_PCM_DECLICK_SAMPLES", "many")
@@ -263,14 +334,80 @@ def test_invalid_pcm_env_values_fall_back_to_defaults(monkeypatch):
 
     config = load_config()
 
-    assert config.pcm_gain == 0.75
+    assert config.audio_mode == "wav"
+    assert config.pcm_gain == 1.0
     assert config.pcm_limit == 0.90
     assert config.pcm_declick_samples == 64
     assert config.pcm_zero_cross_window == 256
 
 
+def test_invalid_audio_mode_falls_back_to_auto(monkeypatch):
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
+    monkeypatch.setenv("STACKCHAN_AUDIO_MODE", "stream")
+
+    config = load_config()
+
+    assert config.audio_mode == "wav"
+
+
+def test_invalid_pcm_transport_falls_back_to_auto(monkeypatch):
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
+    monkeypatch.setenv("STACKCHAN_PCM_TRANSPORT", "bananas")
+
+    config = load_config()
+
+    assert config.pcm_transport == "auto"
+
+
+def test_load_config_defaults_to_wav_and_full_pcm_gain(monkeypatch):
+    monkeypatch.delenv("STACKCHAN_AUDIO_MODE", raising=False)
+    monkeypatch.delenv("STACKCHAN_PCM_GAIN", raising=False)
+    monkeypatch.delenv("STACKCHAN_PCM_LIMIT", raising=False)
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
+
+    config = load_config()
+
+    assert config.audio_mode == "wav"
+    assert config.pcm_transport == "tcp"
+    assert config.pcm_gain == 1.0
+    assert config.pcm_limit == 0.90
+
+
+def test_load_config_accepts_explicit_audio_modes(monkeypatch):
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
+
+    monkeypatch.setenv("STACKCHAN_AUDIO_MODE", "auto")
+    auto_config = load_config()
+
+    monkeypatch.setenv("STACKCHAN_AUDIO_MODE", "pcm")
+    pcm_config = load_config()
+
+    assert auto_config.audio_mode == "auto"
+    assert pcm_config.audio_mode == "pcm"
+
+
+def test_load_config_accepts_explicit_pcm_transports(monkeypatch):
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
+
+    monkeypatch.setenv("STACKCHAN_PCM_TRANSPORT", "udp")
+    udp_config = load_config()
+
+    monkeypatch.setenv("STACKCHAN_PCM_TRANSPORT", "auto")
+    auto_config = load_config()
+
+    monkeypatch.setenv("STACKCHAN_PCM_TRANSPORT", "staged")
+    staged_config = load_config()
+
+    assert udp_config.pcm_transport == "udp"
+    assert auto_config.pcm_transport == "auto"
+    assert staged_config.pcm_transport == "staged"
+
+
 def test_config_reads_pcm_and_timeout_env_aliases(monkeypatch):
     monkeypatch.setenv("STACKCHAN_PCM_SEGMENT_BYTES", "32768")
+    monkeypatch.setenv("STACKCHAN_PCM_TRANSPORT", "tcp")
+    monkeypatch.setenv("STACKCHAN_PCM_STREAM_PORT", "9191")
+    monkeypatch.setenv("STACKCHAN_PCM_STREAM_INITIAL_BUFFER_BYTES", "32768")
     monkeypatch.setenv("STACKCHAN_PCM_MAX_PAYLOAD_BYTES", "1048576")
     monkeypatch.setenv("STACKCHAN_PLAYBACK_START_TIMEOUT_SEC", "7.5")
     monkeypatch.setenv("STACKCHAN_PCM_SEGMENT_POST_TIMEOUT_SEC", "22")
@@ -280,6 +417,9 @@ def test_config_reads_pcm_and_timeout_env_aliases(monkeypatch):
     config = load_config()
 
     assert config.pcm_segment_bytes == 32768
+    assert config.pcm_transport == "tcp"
+    assert config.pcm_stream_port == 9191
+    assert config.pcm_stream_initial_buffer_bytes == 32768
     assert config.max_pcm_payload_bytes == 1048576
     assert config.playback_start_timeout == 7.5
     assert config.pcm_segment_post_timeout == 22
@@ -792,14 +932,16 @@ def test_post_pcm_stream_posts_binary_payload_with_content_length(monkeypatch, t
     assert result["success"] is True
     assert result["segments"] == 1
     assert set(result["timing_ms"]) == {"pcm_total", "fish_first_chunk", "first_segment_posted"}
-    assert request_kwargs["kwargs"]["data"] == struct.pack("<hh", 750, -750)
+    assert request_kwargs["kwargs"]["data"] == struct.pack("<hh", 1000, -1000)
     assert isinstance(request_kwargs["kwargs"]["data"], bytes)
     headers = request_kwargs["kwargs"]["headers"]
     assert headers["Content-Type"].startswith("audio/x-raw")
     assert headers["X-Stackchan-Pcm-Session"] == result["session"]
     assert headers["X-Stackchan-Pcm-Seq"] == "0"
     assert headers["X-Stackchan-Pcm-Final"] == "1"
+    assert headers["X-Stackchan-Pcm-Mode"] == "staged"
     assert "final=1" in request_kwargs["args"][0]
+    assert "mode=staged" in request_kwargs["args"][0]
 
 
 def test_post_pcm_stream_handles_split_sample_boundaries(monkeypatch, tmp_path):
@@ -827,7 +969,46 @@ def test_post_pcm_stream_handles_split_sample_boundaries(monkeypatch, tmp_path):
     )
 
     assert result["success"] is True
-    assert request_kwargs["kwargs"]["data"] == struct.pack("<hh", 750, -750)
+    assert request_kwargs["kwargs"]["data"] == struct.pack("<hh", 1000, -1000)
+
+
+def test_post_pcm_stream_staged_segments_do_not_mark_audio_started(monkeypatch, tmp_path):
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, payload=None, error=None):
+            self._payload = payload or {}
+            self._error = error
+            self.text = "{\"success\":false,\"error\":\"upload failed\"}"
+
+        def raise_for_status(self):
+            if self._error:
+                error = __import__("requests").HTTPError(self._error)
+                error.response = self
+                raise error
+
+        def json(self):
+            return self._payload
+
+    def fake_post(*args, **kwargs):
+        calls.append((args, kwargs))
+        if len(calls) == 1:
+            return FakeResponse({"success": True, "staged": True})
+        return FakeResponse(error="500 Server Error")
+
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.post", fake_post)
+    client = StackchanClient(make_config(pcm_segment_bytes=4))
+
+    with pytest.raises(PcmPlaybackError) as excinfo:
+        post_pcm_stream(
+            client,
+            iter([struct.pack("<hhhh", 1, 2, 3, 4)]),
+            tmp_path,
+            audio_processing,
+        )
+
+    assert excinfo.value.started is False
+    assert calls[0][1]["headers"]["X-Stackchan-Pcm-Mode"] == "staged"
 
 
 def test_wait_for_playback_start_detects_started_ms_change(monkeypatch):
@@ -877,6 +1058,238 @@ def test_post_pcm_stream_raises_for_http_error(monkeypatch, tmp_path):
 
     with pytest.raises(PcmPlaybackError, match="PCM segment HTTP failed"):
         post_pcm_stream(StackchanClient(make_config()), iter([b"\x00\x00"]), tmp_path, audio_processing)
+
+
+def test_post_pcm_tcp_stream_sends_header_and_pcm(monkeypatch, tmp_path):
+    class FakeSocket:
+        def __init__(self):
+            self.sent = []
+            self.response = bytearray(b"OK\n")
+            self.timeout = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, timeout):
+            self.timeout = timeout
+
+        def sendall(self, data):
+            self.sent.append(bytes(data))
+
+        def recv(self, size):
+            assert size == 1
+            if not self.response:
+                return b""
+            data = self.response[:1]
+            del self.response[:1]
+            return bytes(data)
+
+    fake_socket = FakeSocket()
+    calls = []
+
+    def fake_create_connection(address, timeout):
+        calls.append((address, timeout))
+        return fake_socket
+
+    monkeypatch.setattr("mcp_server.stackchan_client.socket.create_connection", fake_create_connection)
+    client = StackchanClient(make_config(pcm_stream_initial_buffer_bytes=4))
+
+    result = post_pcm_tcp_stream(
+        client,
+        iter([struct.pack("<h", 1000), struct.pack("<h", -1000)]),
+        tmp_path,
+        audio_processing,
+    )
+
+    assert result["success"] is True
+    assert result["transport"] == "tcp"
+    assert result["sent_bytes"] == 4
+    assert calls == [(("192.0.2.20", 9090), 3.0)]
+    assert fake_socket.sent[0].startswith(b"STACKCHAN_PCM_STREAM/1 session=")
+    assert b"rate=24000 channels=1 width=2\n" in fake_socket.sent[0]
+    assert fake_socket.sent[1] == struct.pack("<hh", 1000, -1000)
+
+
+def test_post_pcm_tcp_stream_rejection_is_not_started(monkeypatch, tmp_path):
+    class FakeSocket:
+        response = bytearray(b"ERR BUSY\n")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def settimeout(self, _timeout):
+            return None
+
+        def sendall(self, _data):
+            return None
+
+        def recv(self, _size):
+            if not self.response:
+                return b""
+            data = self.response[:1]
+            del self.response[:1]
+            return bytes(data)
+
+    monkeypatch.setattr(
+        "mcp_server.stackchan_client.socket.create_connection",
+        lambda *_args, **_kwargs: FakeSocket(),
+    )
+
+    with pytest.raises(PcmPlaybackError, match="ERR BUSY") as excinfo:
+        post_pcm_tcp_stream(
+            StackchanClient(make_config(pcm_stream_initial_buffer_bytes=2)),
+            iter([b"\x00\x00"]),
+            tmp_path,
+            audio_processing,
+        )
+
+    assert excinfo.value.started is False
+
+
+def test_post_pcm_udp_stream_starts_session_and_sends_framed_packets(monkeypatch, tmp_path):
+    class FakeResponse:
+        def json(self):
+            return {"success": True, "session": "udp-test", "token": 0x12345678, "udp_port": 9091}
+
+    class FakeStatusResponse:
+        def json(self):
+            return {
+                "udp_audio_active": False,
+                "udp_audio_playing": False,
+                "udp_audio_session": "",
+                "udp_last_end_reason": "end",
+                "udp_last_frames_received": 1,
+                "udp_last_frames_lost": 0,
+                "udp_last_underruns": 0,
+            }
+
+    class FakeSocket:
+        def __init__(self, *_args, **_kwargs):
+            self.sent = []
+            self.timeout = None
+
+        def settimeout(self, timeout):
+            self.timeout = timeout
+
+        def sendto(self, data, address):
+            self.sent.append((bytes(data), address))
+
+        def close(self):
+            return None
+
+    fake_socket = FakeSocket()
+    session_posts = []
+
+    def fake_post(url, **kwargs):
+        session_posts.append((url, kwargs))
+        return FakeResponse()
+
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.post", fake_post)
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.get", lambda *_args, **_kwargs: FakeStatusResponse())
+    monkeypatch.setattr("mcp_server.stackchan_client.socket.socket", lambda *_args, **_kwargs: fake_socket)
+    monkeypatch.setattr("mcp_server.stackchan_client.time.sleep", lambda _seconds: None)
+    client = StackchanClient(make_config(pcm_transport="udp"))
+
+    result = post_pcm_udp_stream(
+        client,
+        iter([b"\x00\x00" * (PCM_UDP_FRAME_BYTES // 2)]),
+        tmp_path,
+        audio_processing,
+    )
+
+    assert result["success"] is True
+    assert result["transport"] == "udp"
+    assert result["frames"] == 1
+    assert result["udp_frames_lost"] == 0
+    assert result["udp_underruns"] == 0
+    assert session_posts[0][0] == "http://192.0.2.20:80/audio/session"
+    first_packet, address = fake_socket.sent[0]
+    assert address == ("192.0.2.20", 9091)
+    magic, version, flags, header_len, token, seq, timestamp, payload_len, reserved = struct.unpack(
+        "<4sBBHIIIHH",
+        first_packet[:24],
+    )
+    assert (magic, version, flags, header_len, token, seq, timestamp, payload_len, reserved) == (
+        b"SCP1",
+        1,
+        0,
+        24,
+        0x12345678,
+        0,
+        0,
+        PCM_UDP_FRAME_BYTES,
+        0,
+    )
+    assert len(first_packet[24:]) == PCM_UDP_FRAME_BYTES
+    assert len(fake_socket.sent) == 4
+    assert all(packet[0][5] == 1 for packet in fake_socket.sent[1:])
+
+
+def test_post_pcm_udp_stream_raises_when_device_reports_lost_frames(monkeypatch, tmp_path):
+    class FakeSessionResponse:
+        def json(self):
+            return {"success": True, "session": "udp-test", "token": 0x12345678, "udp_port": 9091}
+
+    class FakeStatusResponse:
+        def json(self):
+            return {
+                "udp_audio_active": False,
+                "udp_audio_playing": False,
+                "udp_audio_session": "",
+                "udp_last_end_reason": "end",
+                "udp_last_frames_received": 1,
+                "udp_last_frames_lost": 1,
+                "udp_last_underruns": 1,
+            }
+
+    class FakeSocket:
+        def settimeout(self, _timeout):
+            return None
+
+        def sendto(self, _data, _address):
+            return None
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.post", lambda *_args, **_kwargs: FakeSessionResponse())
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.get", lambda *_args, **_kwargs: FakeStatusResponse())
+    monkeypatch.setattr("mcp_server.stackchan_client.socket.socket", lambda *_args, **_kwargs: FakeSocket())
+    monkeypatch.setattr("mcp_server.stackchan_client.time.sleep", lambda _seconds: None)
+
+    with pytest.raises(PcmPlaybackError, match="lost=1 underruns=1") as excinfo:
+        post_pcm_udp_stream(
+            StackchanClient(make_config(pcm_transport="udp")),
+            iter([b"\x00\x00" * (PCM_UDP_FRAME_BYTES // 2)]),
+            tmp_path,
+            audio_processing,
+        )
+
+    assert excinfo.value.started is True
+
+
+def test_post_pcm_udp_stream_session_failure_is_not_started(monkeypatch, tmp_path):
+    class FakeResponse:
+        def json(self):
+            return {"success": False, "error": "busy"}
+
+    monkeypatch.setattr("mcp_server.stackchan_client.requests.post", lambda *_args, **_kwargs: FakeResponse())
+
+    with pytest.raises(PcmPlaybackError, match="PCM UDP session failed") as excinfo:
+        post_pcm_udp_stream(
+            StackchanClient(make_config()),
+            iter([b"\x00\x00"]),
+            tmp_path,
+            audio_processing,
+        )
+
+    assert excinfo.value.started is False
 
 
 def test_tools_move_clamps_inputs_before_http_call():
@@ -1041,6 +1454,8 @@ def test_playback_status_formats_runtime_diagnostics():
 
 def test_can_stream_pcm_requires_fish_credentials():
     assert can_stream_pcm(make_config()) is True
+    assert can_stream_pcm(make_config(audio_mode="auto")) is True
+    assert can_stream_pcm(make_config(audio_mode="pcm")) is True
     assert can_stream_pcm(make_config(audio_mode="wav")) is False
     assert can_stream_pcm(make_config(tts_engine="edge-tts")) is False
     assert can_stream_pcm(make_config(fish_audio_key="")) is False


### PR DESCRIPTION
Cloud Fable instance's fix, deployed and verified on-device today.

- firmware: conceal lost UDP PCM frames with ramps instead of hard zeros (declick)
- mcp: make UDP playback verification and pacing reliable
- docs: replace device LAN IP with STACKCHAN_IP placeholder

Verified: two-sentence consecutive UDP playback test on CoreS3 — no distortion, clean pacing. Isa acceptance-tested by ear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)