### PR TITLE
feat(security): wire voice upload server into authed wake session flow

### DIFF
--- a/mcp_server/mcp_tools.py
+++ b/mcp_server/mcp_tools.py
@@ -49,6 +49,15 @@ def format_speech_confirmation(text: str) -> str:
     return f"🗣️ Stack-chan is saying: \"{preview}{suffix}\""
 
 
+def audit_tool_call(name: str, **attributes: object) -> None:
+    parts = []
+    for key, value in attributes.items():
+        if value is not None:
+            parts.append(f"{key}={value!r}")
+    suffix = " " + " ".join(parts) if parts else ""
+    logger.info("Stack-chan MCP tool call: tool=%s%s", name, suffix)
+
+
 def check_audio_dir() -> dict[str, object]:
     return {
         "path": str(AUDIO_DIR),
@@ -118,6 +127,11 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
     def stackchan_say(text: str, lang: str = "zh") -> str:
         request_id = new_request_id()
         say_started = time.perf_counter()
+        audit_tool_call(
+            "stackchan_say",
+            lang=lang,
+            text_len=len(text),
+        )
         start_audio_server(config.audio_serve_port)
 
         try:
@@ -287,6 +301,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool()
     def stackchan_listen(lang: str = "zh") -> str:
+        audit_tool_call("stackchan_listen", lang=lang)
         try:
             result = capture_ready_recording(client, config, lang=lang, audio_dir=AUDIO_DIR)
             return format_listen_result(result)
@@ -295,6 +310,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool()
     def stackchan_move(x: float = 0, y: float = 0, speed: int = 50) -> str:
+        audit_tool_call("stackchan_move", x=x, y=y, speed=speed)
         try:
             x = max(-128, min(128, x))
             y = max(0, min(90, y))
@@ -308,6 +324,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool()
     def stackchan_nod() -> str:
+        audit_tool_call("stackchan_nod")
         try:
             result = client.gesture("nod")
             return "🤖 *nods yes*" if result.get("success") else f"❌ Nod failed: {result}"
@@ -316,6 +333,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool()
     def stackchan_shake() -> str:
+        audit_tool_call("stackchan_shake")
         try:
             result = client.gesture("shake")
             return "🤖 *shakes head no*" if result.get("success") else f"❌ Shake failed: {result}"
@@ -324,6 +342,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool()
     def stackchan_face(expression: str = "calm") -> str:
+        audit_tool_call("stackchan_face", expression=expression)
         if expression not in VALID_FACES:
             return f"❌ Unknown expression. Choose from: {', '.join(VALID_FACES)}"
         try:
@@ -345,6 +364,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool(structured_output=False)
     def stackchan_see() -> list[object] | str:
+        audit_tool_call("stackchan_see")
         try:
             jpeg_data, size = client.snapshot()
             if jpeg_data is None:
@@ -362,6 +382,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool()
     def stackchan_home() -> str:
+        audit_tool_call("stackchan_home")
         try:
             result = client.gesture("home")
             return "🤖 Head returned to home position" if result.get("success") else f"❌ Home failed: {result}"
@@ -370,6 +391,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool()
     def stackchan_status() -> str:
+        audit_tool_call("stackchan_status")
         try:
             status = client.audio_status()
             return f"✅ Stack-chan online at {config.stackchan_ip} | Mode: {status.get('mode', '?')} | Recording ready: {status.get('ready', '?')}"
@@ -381,15 +403,18 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
     @mcp.tool()
     def stackchan_health() -> str:
         """Non-destructive health check for config, dependencies, and device status."""
+        audit_tool_call("stackchan_health")
         return json.dumps(build_health_report(client, config), ensure_ascii=False, indent=2)
 
     @mcp.tool()
     def stackchan_config_summary() -> str:
         """Return Stack-chan runtime config without secrets."""
+        audit_tool_call("stackchan_config_summary")
         return json.dumps(config_summary(config), ensure_ascii=False, indent=2)
 
     @mcp.tool()
     def stackchan_playback_status() -> str:
+        audit_tool_call("stackchan_playback_status")
         try:
             status = client.playback_status()
             return (
@@ -413,6 +438,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool()
     def stackchan_voice_inbox(limit: int = 10) -> str:
+        audit_tool_call("stackchan_voice_inbox", limit=limit)
         try:
             events = read_events(limit=limit)
             return format_events(events)
@@ -421,6 +447,7 @@ def register_tools(mcp, client: StackchanClient, config: StackchanConfig, image_
 
     @mcp.tool()
     def stackchan_voice_inbox_clear() -> str:
+        audit_tool_call("stackchan_voice_inbox_clear")
         try:
             clear_events()
             return "Stack-chan voice inbox cleared."

--- a/scripts/stackchan_frontend_session.py
+++ b/scripts/stackchan_frontend_session.py
@@ -10,6 +10,10 @@ from pathlib import Path
 from typing import Any
 
 
+class SessionResolutionError(RuntimeError):
+    pass
+
+
 def default_registry_path() -> Path:
     return Path(os.environ.get("STACKCHAN_FRONTEND_REGISTRY", "web-sessions.json"))
 
@@ -19,11 +23,11 @@ def load_sessions(path: str | Path | None = None) -> list[dict[str, Any]]:
     try:
         raw = json.loads(registry_path.read_text(encoding="utf-8"))
     except FileNotFoundError:
-        raise SystemExit(f"session registry not found: {registry_path}") from None
+        raise SessionResolutionError(f"session registry not found: {registry_path}") from None
     except json.JSONDecodeError as exc:
-        raise SystemExit(f"session registry is not valid JSON: {registry_path}: {exc}") from None
+        raise SessionResolutionError(f"session registry is not valid JSON: {registry_path}: {exc}") from None
     if not isinstance(raw, list):
-        raise SystemExit(f"session registry must be a JSON array: {registry_path}")
+        raise SessionResolutionError(f"session registry must be a JSON array: {registry_path}")
     return [item for item in raw if isinstance(item, dict)]
 
 
@@ -73,11 +77,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     args = build_parser().parse_args()
-    session = select_session(
-        load_sessions(args.registry),
-        title=args.title,
-        include_archived=args.include_archived,
-    )
+    try:
+        session = select_session(
+            load_sessions(args.registry),
+            title=args.title,
+            include_archived=args.include_archived,
+        )
+    except SessionResolutionError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
     if not session:
         print("no matching frontend session", file=sys.stderr)
         return 1

--- a/scripts/stackchan_frontend_wake.py
+++ b/scripts/stackchan_frontend_wake.py
@@ -83,6 +83,7 @@ def forward_to_frontend(
     quiet_minutes: int = 0,
     prompt_prefix: str = DEFAULT_PROMPT_PREFIX,
     wake_words: tuple[str, ...] = (),
+    source: str = "",
     request_id: str | None = None,
 ) -> dict[str, Any]:
     started = time.perf_counter()
@@ -138,6 +139,8 @@ def forward_to_frontend(
         "force": force,
         "quiet_minutes": quiet_minutes,
     }
+    if source:
+        payload["source"] = source
     if model:
         payload["model"] = model
 

--- a/scripts/stackchan_voice_bridge.py
+++ b/scripts/stackchan_voice_bridge.py
@@ -114,6 +114,7 @@ def forward_event_to_frontend(event: dict[str, Any], args: argparse.Namespace) -
         quiet_minutes=args.wake_quiet_minutes,
         prompt_prefix=args.prompt_prefix,
         wake_words=parse_wake_words(args.wake_words),
+        source=str(event.get("source") or "stackchan_mic"),
     )
 
 

--- a/scripts/stackchan_voice_bridge.py
+++ b/scripts/stackchan_voice_bridge.py
@@ -12,7 +12,11 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from scripts.stackchan_frontend_session import load_sessions, select_session  # noqa: E402
+from scripts.stackchan_frontend_session import (  # noqa: E402
+    SessionResolutionError,
+    load_sessions,
+    select_session,
+)
 from scripts.stackchan_frontend_wake import (  # noqa: E402
     DEFAULT_PROMPT_PREFIX,
     forward_to_frontend,
@@ -84,18 +88,21 @@ def resolve_wake_session(session_id: str, title: str = "") -> str:
     if title:
         session = select_session(load_sessions(), title=title)
         if not session:
-            raise SystemExit(f"no matching frontend session title: {title}")
+            raise SessionResolutionError(f"no matching frontend session title: {title}")
         return str(session.get("id") or "")
     if session_id in {"latest", "auto"}:
         session = select_session(load_sessions())
         if not session:
-            raise SystemExit("no non-archived frontend session found")
+            raise SessionResolutionError("no non-archived frontend session found")
         return str(session.get("id") or "")
     return session_id
 
 
 def forward_event_to_frontend(event: dict[str, Any], args: argparse.Namespace) -> dict[str, Any] | None:
-    wake_session_id = resolve_wake_session(args.wake_session_id, args.wake_session_title)
+    try:
+        wake_session_id = resolve_wake_session(args.wake_session_id, args.wake_session_title)
+    except SessionResolutionError as exc:
+        return {"ok": False, "skipped": f"frontend session not resolved: {exc}"}
     wake_url = args.wake_url
     if not wake_url and wake_session_id:
         wake_url = "http://127.0.0.1:3200/wake"

--- a/scripts/stackchan_voice_upload_server.py
+++ b/scripts/stackchan_voice_upload_server.py
@@ -27,15 +27,20 @@ from mcp_server.stackchan_config import StackchanConfig, load_config  # noqa: E4
 from mcp_server.telemetry import emit_event, new_request_id  # noqa: E402
 from mcp_server.voice_inbox import append_event, resolve_inbox_path  # noqa: E402
 from scripts.stackchan_frontend_wake import (  # noqa: E402
-    DEFAULT_PROMPT_PREFIX,
     forward_to_frontend,
     parse_wake_words,
 )
-from scripts.stackchan_voice_bridge import load_env_file, should_append_to_inbox  # noqa: E402
+from scripts.stackchan_voice_bridge import (  # noqa: E402
+    load_env_file,
+    load_frontend_token,
+    resolve_wake_session,
+    should_append_to_inbox,
+)
 
 DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 DEFAULT_UPLOAD_RATE_PER_MINUTE = 12
 DEFAULT_UPLOAD_RATE_WINDOW_SECONDS = 60.0
+DEFAULT_UPLOAD_PROMPT_PREFIX = "[前端语音输入] "
 TOKEN_QUERY_RE = re.compile(r"([?&]token=)[^\s&]+")
 
 
@@ -46,6 +51,7 @@ class ServerOptions:
     inbox_path: Path | None
     wake_url: str
     wake_session_id: str
+    wake_session_title: str
     wake_token: str
     wake_model: str
     wake_timeout: float
@@ -483,6 +489,8 @@ def build_health_payload(options: ServerOptions) -> dict[str, Any]:
         "service": "stackchan_voice_upload_server",
         "inbox": str(options.inbox_path) if options.inbox_path else None,
         "frontend": bool(options.wake_url and options.wake_session_id),
+        "wake_session_id": options.wake_session_id,
+        "wake_session_title": options.wake_session_title,
         "config": {
             "lang": options.lang,
             "max_bytes": options.max_bytes,
@@ -498,6 +506,10 @@ def build_health_payload(options: ServerOptions) -> dict[str, Any]:
             "allowed_origins": list(options.allowed_origins),
         },
     }
+
+
+def resolve_frontend_wake_session(options: ServerOptions) -> str:
+    return resolve_wake_session(options.wake_session_id, options.wake_session_title)
 
 
 def write_rate_limit_error(handler: BaseHTTPRequestHandler) -> None:
@@ -633,21 +645,32 @@ class VoiceUploadHandler(BaseHTTPRequestHandler):
             inbox_ms = 0
 
         frontend_started = time.perf_counter()
-        frontend = forward_to_frontend(
-            event,
-            wake_url=self.voice_server.options.wake_url,
-            session_id=self.voice_server.options.wake_session_id,
-            token=self.voice_server.options.wake_token,
-            model=self.voice_server.options.wake_model,
-            timeout=self.voice_server.options.wake_timeout,
-            retries=self.voice_server.options.wake_retries,
-            retry_delay=self.voice_server.options.wake_retry_delay,
-            force=self.voice_server.options.wake_force,
-            quiet_minutes=self.voice_server.options.wake_quiet_minutes,
-            prompt_prefix=self.voice_server.options.prompt_prefix,
-            wake_words=self.voice_server.options.wake_words,
-            request_id=request_id,
-        )
+        try:
+            wake_session_id = resolve_frontend_wake_session(self.voice_server.options)
+        except SystemExit as exc:
+            wake_session_id = ""
+            frontend = {
+                "ok": False,
+                "skipped": f"frontend session not resolved: {exc}",
+                "timing_ms": {"wake_total": 0},
+            }
+        else:
+            frontend = forward_to_frontend(
+                event,
+                wake_url=self.voice_server.options.wake_url,
+                session_id=wake_session_id,
+                token=self.voice_server.options.wake_token,
+                model=self.voice_server.options.wake_model,
+                timeout=self.voice_server.options.wake_timeout,
+                retries=self.voice_server.options.wake_retries,
+                retry_delay=self.voice_server.options.wake_retry_delay,
+                force=self.voice_server.options.wake_force,
+                quiet_minutes=self.voice_server.options.wake_quiet_minutes,
+                prompt_prefix=self.voice_server.options.prompt_prefix,
+                wake_words=self.voice_server.options.wake_words,
+                source=str(event.get("source") or "voice_upload"),
+                request_id=request_id,
+            )
         frontend_ms = round((time.perf_counter() - frontend_started) * 1000)
         timing_ms = {
             "upload_read": read_ms,
@@ -721,6 +744,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.environ.get("STACKCHAN_FRONTEND_SESSION_ID", ""),
         help="Frontend session UUID to receive transcripts.",
     )
+    parser.add_argument(
+        "--wake-session-title",
+        default=os.environ.get("STACKCHAN_FRONTEND_SESSION_TITLE", ""),
+        help="Resolve the latest non-archived frontend session whose title contains this text.",
+    )
     parser.add_argument("--wake-token", default=os.environ.get("STACKCHAN_FRONTEND_TOKEN", ""))
     parser.add_argument("--wake-model", default=os.environ.get("STACKCHAN_FRONTEND_MODEL", ""))
     parser.add_argument(
@@ -752,7 +780,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--prompt-prefix",
-        default=os.environ.get("STACKCHAN_FRONTEND_PROMPT_PREFIX", DEFAULT_PROMPT_PREFIX),
+        default=os.environ.get(
+            "STACKCHAN_VOICE_UPLOAD_PROMPT_PREFIX",
+            os.environ.get("STACKCHAN_FRONTEND_PROMPT_PREFIX", DEFAULT_UPLOAD_PROMPT_PREFIX),
+        ),
     )
     parser.add_argument(
         "--wake-words",
@@ -795,6 +826,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     load_env_file(REPO_ROOT / ".env")
+    load_frontend_token()
     args = build_parser().parse_args()
     config = load_config()
     wake_url = args.wake_url
@@ -806,6 +838,7 @@ def main() -> int:
         inbox_path=None if args.no_inbox else resolve_inbox_path(args.inbox),
         wake_url=wake_url,
         wake_session_id=args.wake_session_id,
+        wake_session_title=args.wake_session_title,
         wake_token=args.wake_token,
         wake_model=args.wake_model,
         wake_timeout=args.wake_timeout,

--- a/scripts/stackchan_voice_upload_server.py
+++ b/scripts/stackchan_voice_upload_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import logging
 import os
 import re
 import sys
@@ -26,6 +27,7 @@ from mcp_server.audio_server import AUDIO_DIR  # noqa: E402
 from mcp_server.stackchan_config import StackchanConfig, load_config  # noqa: E402
 from mcp_server.telemetry import emit_event, new_request_id  # noqa: E402
 from mcp_server.voice_inbox import append_event, resolve_inbox_path  # noqa: E402
+from scripts.stackchan_frontend_session import SessionResolutionError  # noqa: E402
 from scripts.stackchan_frontend_wake import (  # noqa: E402
     forward_to_frontend,
     parse_wake_words,
@@ -36,6 +38,8 @@ from scripts.stackchan_voice_bridge import (  # noqa: E402
     resolve_wake_session,
     should_append_to_inbox,
 )
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_UPLOAD_BYTES = 10 * 1024 * 1024
 DEFAULT_UPLOAD_RATE_PER_MINUTE = 12
@@ -647,13 +651,16 @@ class VoiceUploadHandler(BaseHTTPRequestHandler):
         frontend_started = time.perf_counter()
         try:
             wake_session_id = resolve_frontend_wake_session(self.voice_server.options)
-        except SystemExit as exc:
+        except SessionResolutionError as exc:
             wake_session_id = ""
             frontend = {
                 "ok": False,
                 "skipped": f"frontend session not resolved: {exc}",
                 "timing_ms": {"wake_total": 0},
             }
+            logger.warning(
+                "frontend wake session unresolved; skipping wake forward, upload still recorded: %s", exc
+            )
         else:
             frontend = forward_to_frontend(
                 event,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,3 +1,4 @@
+import argparse
 import asyncio
 import importlib.util
 import json
@@ -50,6 +51,7 @@ from scripts import (
     stackchan_voice_upload_server,
 )
 from scripts.stackchan_voice_bridge import (
+    forward_event_to_frontend,
     load_env_file,
     load_frontend_token,
     should_append_to_inbox,
@@ -951,6 +953,40 @@ def test_frontend_session_selects_latest_by_title():
 
     assert selected is not None
     assert selected["id"] == "room4-new"
+
+
+def test_load_sessions_missing_registry_raises_session_resolution_error(tmp_path):
+    missing_path = tmp_path / "does-not-exist.json"
+
+    with pytest.raises(stackchan_frontend_session.SessionResolutionError):
+        stackchan_frontend_session.load_sessions(missing_path)
+
+
+def test_forward_event_to_frontend_survives_missing_registry(tmp_path, monkeypatch):
+    missing_registry = tmp_path / "web-sessions.json"
+    monkeypatch.setenv("STACKCHAN_FRONTEND_REGISTRY", str(missing_registry))
+
+    args = argparse.Namespace(
+        wake_session_id="latest",
+        wake_session_title="",
+        wake_url="",
+        wake_token="",
+        wake_model="",
+        wake_timeout=3,
+        wake_retries=0,
+        wake_retry_delay=0,
+        wake_no_force=False,
+        wake_quiet_minutes=0,
+        prompt_prefix="",
+        wake_words="",
+    )
+
+    result = forward_event_to_frontend({"type": "transcript", "text": "hi"}, args)
+
+    assert result is not None
+    assert result["ok"] is False
+    assert "skipped" in result
+    assert "web-sessions.json" in result["skipped"] or "session registry not found" in result["skipped"]
 
 
 def test_voice_inbox_appends_reads_formats_and_clears(tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib.util
 import json
+import logging
 import os
 import struct
 import sys
@@ -291,6 +292,36 @@ def test_speech_confirmation_omits_transport_diagnostics():
     assert "…" in result
 
 
+def test_stackchan_say_audit_log_records_length_without_speech_text(monkeypatch, tmp_path, caplog):
+    secret_text = "这段 Stack-chan say 原文应该留在会话备份里，但不要复制进 MCP 服务日志"
+    wav_path = tmp_path / "speech.wav"
+    write_wav(wav_path)
+
+    class FakeClient:
+        def playback_status(self):
+            return {"playing": False, "started_ms": 1}
+
+        def play(self, _url):
+            return {"success": True}
+
+        def wait_for_playback_start(self, baseline_started_ms=None):
+            return {"started": True, "status": {"started_ms": baseline_started_ms}}
+
+    monkeypatch.setattr("mcp_server.mcp_tools.start_audio_server", lambda _port: None)
+    monkeypatch.setattr("mcp_server.audio_processing.generate_tts", lambda *_args, **_kwargs: wav_path)
+
+    caplog.set_level(logging.INFO, logger="mcp_server.mcp_tools")
+    mcp = FakeFastMCP()
+    register_tools(mcp, FakeClient(), make_config(audio_mode="wav"), image_cls=None)
+
+    result = mcp.tools["stackchan_say"](secret_text, lang="zh")
+
+    assert secret_text in result
+    assert "tool=stackchan_say" in caplog.text
+    assert f"text_len={len(secret_text)}" in caplog.text
+    assert secret_text not in caplog.text
+
+
 def test_preferred_pcm_auto_uses_tcp_before_experimental_udp(monkeypatch, tmp_path):
     calls = []
 
@@ -458,6 +489,7 @@ def test_config_reads_pcm_and_timeout_env_aliases(monkeypatch):
 
 
 def test_config_loads_mcp_auth_token_from_env(monkeypatch):
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
     monkeypatch.setenv("STACKCHAN_MCP_AUTH_TOKEN", "s3cr3t-token-value")
 
     config = load_config()
@@ -633,6 +665,7 @@ def test_voice_upload_recorder_page_exposes_upload_ui():
             inbox_path=None,
             wake_url="http://127.0.0.1:3200/wake",
             wake_session_id="117067d6-1111-2222-3333-444444444444",
+            wake_session_title="",
             wake_token="",
             wake_model="",
             wake_timeout=3,
@@ -654,6 +687,53 @@ def test_voice_upload_recorder_page_exposes_upload_ui():
     assert "X-Stackchan-Upload-Token" in html
     assert "secret-token-for-test" not in html
     assert "小塔 / 机器人" in html
+
+
+def test_voice_upload_default_prompt_prefix_separates_frontend_upload(monkeypatch):
+    monkeypatch.delenv("STACKCHAN_VOICE_UPLOAD_PROMPT_PREFIX", raising=False)
+    monkeypatch.delenv("STACKCHAN_FRONTEND_PROMPT_PREFIX", raising=False)
+
+    parser = stackchan_voice_upload_server.build_parser()
+    args = parser.parse_args([])
+
+    assert args.prompt_prefix == "[前端语音输入] "
+
+
+def test_voice_upload_resolves_latest_wake_session(monkeypatch):
+    resolved = []
+
+    def fake_resolve(session_id, title=""):
+        resolved.append((session_id, title))
+        return "117067d6-1111-2222-3333-444444444444"
+
+    monkeypatch.setattr(stackchan_voice_upload_server, "resolve_wake_session", fake_resolve)
+
+    session_id = stackchan_voice_upload_server.resolve_frontend_wake_session(
+        stackchan_voice_upload_server.ServerOptions(
+            lang="zh",
+            max_bytes=1024,
+            inbox_path=None,
+            wake_url="http://127.0.0.1:3200/wake",
+            wake_session_id="latest",
+            wake_session_title="起居室",
+            wake_token="agent-token",
+            wake_model="",
+            wake_timeout=3,
+            wake_retries=0,
+            wake_retry_delay=0,
+            wake_force=True,
+            wake_quiet_minutes=0,
+            prompt_prefix="[Stack-chan语音输入] ",
+            wake_words=("小塔", "机器人"),
+            upload_token="secret-token-for-test",
+            upload_rate_per_minute=12,
+            upload_rate_window_seconds=60,
+            allowed_origins=(),
+        )
+    )
+
+    assert session_id == "117067d6-1111-2222-3333-444444444444"
+    assert resolved == [("latest", "起居室")]
 
 
 def test_voice_upload_token_authorization():
@@ -777,6 +857,7 @@ def test_voice_upload_frontend_forwarding_posts_wake_request(monkeypatch):
         model="claude-opus-4-6[1m]",
         timeout=3,
         wake_words=("小塔", "机器人"),
+        source="voice_upload",
     )
 
     assert result["ok"] is True
@@ -790,6 +871,7 @@ def test_voice_upload_frontend_forwarding_posts_wake_request(monkeypatch):
                 "prompt": "[Stack-chan语音输入] 小塔，听得到吗？",
                 "force": True,
                 "quiet_minutes": 0,
+                "source": "voice_upload",
                 "model": "claude-opus-4-6[1m]",
             },
             "headers": {
@@ -833,6 +915,7 @@ def test_voice_upload_frontend_forwarding_retries_busy(monkeypatch):
         session_id="117067d6-1111-2222-3333-444444444444",
         retries=1,
         retry_delay=0.1,
+        source="voice_upload",
     )
 
     assert result["ok"] is True
@@ -841,6 +924,7 @@ def test_voice_upload_frontend_forwarding_retries_busy(monkeypatch):
     assert result["body"] == {"ok": True}
     assert set(result["timing_ms"]) == {"wake_post", "wake_total"}
     assert len(calls) == 2
+    assert calls[0]["json"]["source"] == "voice_upload"
 
 
 def test_frontend_session_selects_latest_non_archived():


### PR DESCRIPTION
Part of the Tailscale-private hardening after the 7/7 unauthorized access incident. Staged locally by the security refactor session; pushed so cloud engineers see the full current state.

**Known issue for next engineer**: Stack-chan mic/voice-upload path is broken since this hardening round (inbox last entry 2026-07-06 15:03, device audio ready:false, mic_state idle, physical restart did not help). Suspect: firmware/bridge side not carrying the new auth token, or upload server auth rejecting device posts. See PR diff for the auth wiring that changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)