### PR TITLE
Post-#21 fixes: touch, audio publish resilience, firmware recovery, false-red playback check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,7 @@ AUDIO_SERVE_PORT="5099"
 # asynchronous directory mirror. Example: macbook-isa:stackchan_audio/
 STACKCHAN_AUDIO_PUBLISH_TARGET=""
 STACKCHAN_AUDIO_PUBLISH_TIMEOUT_SEC="20"
+STACKCHAN_AUDIO_PUBLISH_ATTEMPTS="2"
 # Use "curl" when a macOS LaunchAgent can reach the device with /usr/bin/curl
 # but Python sockets fail with "No route to host" due to Local Network privacy.
 STACKCHAN_HTTP_TRANSPORT="requests"

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ STACKCHAN_IP="192.0.2.20"
 STACKCHAN_PORT="80"
 MAC_IP="192.0.2.10"
 AUDIO_SERVE_PORT="5099"
+# Optional when the HTTP audio server runs on another host. The current WAV is
+# published synchronously before /play, preventing the device from racing an
+# asynchronous directory mirror. Example: macbook-isa:stackchan_audio/
+STACKCHAN_AUDIO_PUBLISH_TARGET=""
+STACKCHAN_AUDIO_PUBLISH_TIMEOUT_SEC="20"
 # Use "curl" when a macOS LaunchAgent can reach the device with /usr/bin/curl
 # but Python sockets fail with "No route to host" due to Local Network privacy.
 STACKCHAN_HTTP_TRANSPORT="requests"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ build/
 .env.*
 !.env.example
 firmware/src/config.h
+firmware/src/config.h.bak-*
 deploy/macos/*.plist
 
 # PlatformIO

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ stackchan_audio/
 .stackchan_audio/
 stackchan_otel.jsonl
 voice_inbox.jsonl
+relink.sh

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,8 +30,10 @@ Treat any public MCP URL as sensitive operational infrastructure.
 
 Voice upload endpoints require `STACKCHAN_VOICE_UPLOAD_TOKEN` whenever the
 receiver binds a non-loopback address. Send it with the
-`X-Stackchan-Upload-Token` header; query-string tokens are deprecated because
-URLs can leak through browser history and copied links.
+`X-Stackchan-Upload-Token` header. The recorder page can migrate a token from
+an older bookmarked URL into `sessionStorage`, but the upload API rejects
+query-string tokens because URLs can leak through browser history and copied
+links.
 
 The generated-WAV server listens on the LAN so the device can fetch speech
 audio. Responses are marked `no-store`, but the endpoint is not authenticated.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -429,7 +429,10 @@ Important environment variables:
   file and waits for rsync to finish before sending `/play`, so the device cannot
   race an asynchronous directory mirror.
 - `STACKCHAN_AUDIO_PUBLISH_TIMEOUT_SEC`: timeout for that synchronous publish;
-  default `20` seconds.
+  default `20` seconds per attempt.
+- `STACKCHAN_AUDIO_PUBLISH_ATTEMPTS`: bounded retry count for transient SSH,
+  Tailscale, or host-wake failures; default `2`, clamped to `1..3`. A timed-out
+  attempt terminates its full rsync/ssh process group before retrying.
 - `TTS_ENGINE`: `fish-audio` or `edge-tts`.
 - `FISH_AUDIO_KEY`: required for Fish Audio TTS/ASR.
 - `EDGE_TTS_BIN`: path to `edge-tts` when using the edge TTS fallback.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -376,9 +376,9 @@ It uses RMS thresholds to trigger recording and to end after silence.
 - For phone tests, set `STACKCHAN_VOICE_UPLOAD_TOKEN`, open the recorder as
   `https://...trycloudflare.com/`, and enter the token in the page. The page
   sends it as `X-Stackchan-Upload-Token`; unauthenticated uploads receive HTTP
-  401. Older `?token=...` links remain accepted for compatibility, but they are
-  deprecated; the page moves that token into `sessionStorage` and cleans the
-  address bar.
+  401. When an older recorder bookmark contains `?token=...`, the page moves
+  that token into `sessionStorage` and cleans the address bar. The upload API
+  never accepts query-string tokens.
 - For daily phone use, point your own HTTPS route or reverse proxy at
   `http://localhost:8767` and set `STACKCHAN_VOICE_PUBLIC_URL` to that public
   recorder URL. If you use Cloudflare's default certificate coverage, keep the

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -424,6 +424,12 @@ Important environment variables:
 - `STACKCHAN_PORT`: device HTTP port, usually `80`.
 - `MAC_IP`: host IP used in generated audio URLs.
 - `AUDIO_SERVE_PORT`: local HTTP port used to serve generated WAV files.
+- `STACKCHAN_AUDIO_PUBLISH_TARGET`: optional rsync destination for deployments
+  where the WAV HTTP server runs on another host. The MCP publishes the current
+  file and waits for rsync to finish before sending `/play`, so the device cannot
+  race an asynchronous directory mirror.
+- `STACKCHAN_AUDIO_PUBLISH_TIMEOUT_SEC`: timeout for that synchronous publish;
+  default `20` seconds.
 - `TTS_ENGINE`: `fish-audio` or `edge-tts`.
 - `FISH_AUDIO_KEY`: required for Fish Audio TTS/ASR.
 - `EDGE_TTS_BIN`: path to `edge-tts` when using the edge TTS fallback.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -265,6 +265,10 @@ The legacy immediate HTTP PCM segment path remains available for direct tests:
 - WAV playback treats an active device-side download as a pending playback, so
   additional `/play` requests are held in the logical audio queue instead of
   being dropped by the lower-level download queue.
+- WAV downloads use bounded connect, inactivity, and total-transfer timeouts.
+  The worker publishes exactly one success or failure completion event, and a
+  60-second watchdog restarts the device only if that normal recovery path
+  cannot clear the in-flight state.
 - The logical WAV queue accepts up to 16 pending items. Additional `/play`
   requests return `503 {"success":false,"error":"play queue full"}`.
 - Queued WAV items keep priority ordering; items with the same priority are
@@ -446,7 +450,8 @@ The server writes generated and captured media under `/tmp/stackchan_audio`.
 `stackchan_playback_status()` calls firmware `GET /playback/status` and is the
 preferred live diagnostic for playback bugs because it does not consume
 recordings and reports queue depth, PCM state, microphone state, gesture state,
-heap, and PSRAM.
+heap, and PSRAM. For WAV download failures, compare `download_in_flight` with
+`download_age_ms`; `download_watchdog_ms` reports the final recovery threshold.
 
 Run in stdio mode:
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -347,7 +347,9 @@ It uses RMS thresholds to trigger recording and to end after silence.
   the token optional for compatibility.
 - Both voice paths read `AGENT_HOST_TOKEN` from `STACKCHAN_FRONTEND_ENV` when
   `STACKCHAN_FRONTEND_TOKEN` is unset. This avoids copying the frontend token
-  into the Stack-chan repo.
+  into the Stack-chan repo. The file-backed token is resolved immediately before
+  each frontend forward, so relay token rotation does not require restarting the
+  long-running voice bridge or upload receiver.
 - The voice paths intentionally do not guess the active frontend room. Use
   `STACKCHAN_FRONTEND_SESSION_ID=<uuid>` when the voice prompt should enter a
   specific frontend session; omit it for inbox-only capture.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -51,7 +51,10 @@ This is the shared contract between the CoreS3 firmware and the MCP server.
   - Clears any previous recording. Recording behavior is always MCP pull mode.
 
 - `GET /audio/status`
-  - Returns `{"ready":true|false,"mode":"mcp"}`.
+  - Returns `{"ready":true|false,"mode":"mcp","source":"voice|touch|none"}`.
+  - `source=touch` marks a recording explicitly started by tapping the top
+    touch strip. The host bridge uses this marker to bypass wake-word matching
+    and forwards the transcript with the `（触摸）` prefix.
 
 - `GET /audio`
   - Returns the latest WAV recording.
@@ -76,6 +79,22 @@ This is the shared contract between the CoreS3 firmware and the MCP server.
 - `GET /face`
   - Returns `{"face":"<name>"}`.
 
+## Touch Strip
+
+- The three-zone Si12T strip on top of Stack-chan is polled by the firmware.
+- A short tap starts a forced microphone recording without waiting for the
+  normal RMS trigger. The user has up to four seconds to begin speaking; after
+  speech starts, the normal silence and maximum-duration rules end recording.
+  Audio playback, PCM streaming, or another recording causes the request to be
+  rejected instead of interrupting the active path.
+- A forward swipe followed by a backward swipe, or the reverse order, within
+  1500 ms is treated as petting. While audio and recording are idle, petting
+  shows the `happy` face for five seconds and starts the non-blocking shake
+  gesture. Touch never starts speech or a network request.
+- The CoreS3 camera shares GPIO 11/12 with the internal I2C bus. `/snapshot`
+  temporarily suspends touch, uses the camera, then restores the I2C bus and
+  reinitializes the Si12T on every success and failure path.
+
 ## Diagnostics
 
 - `GET /env`
@@ -91,6 +110,11 @@ This is the shared contract between the CoreS3 firmware and the MCP server.
     calibration and ADC readings on the host side.
 
 - `GET /servo/status`
+- `GET /touch/status`
+  - Returns whether the Si12T is available or temporarily suspended, the
+    current front/middle/back intensity values, the latest click/hold/swipe or
+    petting event, recording request/failure counters, pet counters, and
+    `resume_failure_count` for camera handoff failures.
 - `GET /playback/status`
   - Includes playback state, PCM queue depth, audio queue depth, download
     queue depth, UDP/TCP PCM stream state, and whether a WAV download is

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -95,5 +95,7 @@ This is the shared contract between the CoreS3 firmware and the MCP server.
   - Includes playback state, PCM queue depth, audio queue depth, download
     queue depth, UDP/TCP PCM stream state, and whether a WAV download is
     currently in flight.
+  - `download_age_ms` reports the age of the active WAV download, or `0` when
+    idle. `download_watchdog_ms` reports the automatic recovery threshold.
 - `GET /snapshot`
   - Returns a JPEG image.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -50,8 +50,14 @@ PCM under `/tmp/stackchan_audio/diag_<session>.pcm`.
 - `playing`, `kind`, and `pcm_session` for stuck playback sessions.
 - `queued_pcm_segments`, `queued_pcm_bytes`, and `audio_queue_depth` for queue
   growth.
-- `mic_state` and `mic_resume_requested` for microphone recovery after
-  playback.
+- `mic_state`, `mic_running`, and `mic_resume_requested` for microphone
+  recovery after playback. The voice-trigger state can remain `idle` even
+  when capture is stopped, so `mic_running=true` is the authoritative healthy
+  listener signal.
+- `mic_frame_count` and `mic_last_frame_ms` for live capture progress;
+  `mic_recent_peak_rms` against the configured trigger threshold; and
+  `mic_record_failure_count`, `mic_trigger_count`, and
+  `mic_stored_recording_count` to separate capture, VAD, and storage failures.
 - `gesture` for stuck servo gestures.
 - `free_heap` and `free_psram` for memory pressure after repeated playback or
   capture cycles.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -50,6 +50,8 @@ PCM under `/tmp/stackchan_audio/diag_<session>.pcm`.
 - `playing`, `kind`, and `pcm_session` for stuck playback sessions.
 - `queued_pcm_segments`, `queued_pcm_bytes`, and `audio_queue_depth` for queue
   growth.
+- `download_in_flight` and `download_age_ms` for a stalled WAV transfer;
+  `download_watchdog_ms` is the device's final automatic recovery threshold.
 - `mic_state`, `mic_running`, and `mic_resume_requested` for microphone
   recovery after playback. The voice-trigger state can remain `idle` even
   when capture is stopped, so `mic_running=true` is the authoritative healthy
@@ -80,6 +82,8 @@ Keep alerts deployment-local. Good first alerts are:
 - Firmware probes fail for more than one or two polling intervals.
 - `/playback/status` reports growing PCM or audio queues while `playing` does
   not clear.
+- `download_in_flight=true` approaches `download_watchdog_ms` instead of
+  clearing after a transfer failure.
 - `free_heap` or `free_psram` drops steadily across repeated playback cycles.
 - Upload receiver `/health` fails while the public recorder URL is expected to
   be live.

--- a/docs/remote-wav-publish-race-troubleshooting-2026-08-23.md
+++ b/docs/remote-wav-publish-race-troubleshooting-2026-08-23.md
@@ -1,0 +1,55 @@
+# Remote WAV publish race (2026-08-23)
+
+## Symptom
+
+`stackchan_say` intermittently returned:
+
+```text
+Play was queued but playback did not start: kind=idle playing=False current_bytes=0
+```
+
+The firmware was responsive, `download_in_flight` was false, and the microphone
+continued recording. Restarting the device was not required.
+
+## Evidence
+
+The MacBook audio server log showed the device requesting the exact generated
+filename and receiving `404 File not found`. The file appeared on the MacBook
+later with a matching hash. The mini was copying `tts_*.wav` with a separate
+two-second polling loop, while the MCP sent `/play` immediately after TTS
+generation.
+
+The MacBook wait server could delay a missing-file response for eight seconds,
+but that only reduced the race. It did not establish that the current file had
+finished publishing, and the MCP playback-start timeout was shorter than the
+wait window.
+
+## Root cause
+
+WAV publication and `/play` were independent asynchronous paths:
+
+1. MCP generated a local WAV.
+2. A polling LaunchAgent eventually noticed and rsynced it to the MacBook.
+3. MCP immediately told Stack-chan to download the MacBook URL.
+
+When step 3 overtook step 2, the MacBook returned 404 and the firmware safely
+returned to idle.
+
+## Fix
+
+When `STACKCHAN_AUDIO_PUBLISH_TARGET` is configured, the MCP now rsyncs only the
+current WAV and waits for successful completion before sending `/play`. Rsync's
+normal temporary-file rename keeps the destination atomic. Publication has a
+bounded timeout and failures are returned before any playback request is sent.
+
+The old `xyz.migratorybird.audio-push` polling LaunchAgent is disabled in the
+two-host deployment to avoid duplicate concurrent transfers. Its script remains
+available as a rollback mechanism.
+
+## Verification
+
+- Python MCP tests: `95 passed`.
+- Ruff checks passed for the changed Python files.
+- A live short TTS request published the same SHA-256 on mini and MacBook.
+- MacBook `5061` log returned HTTP 200 for the new filename.
+- Device `started_ms` advanced and the microphone resumed recording afterward.

--- a/docs/remote-wav-publish-race-troubleshooting-2026-08-23.md
+++ b/docs/remote-wav-publish-race-troubleshooting-2026-08-23.md
@@ -46,6 +46,11 @@ The old `xyz.migratorybird.audio-push` polling LaunchAgent is disabled in the
 two-host deployment to avoid duplicate concurrent transfers. Its script remains
 available as a rollback mechanism.
 
+If a transient Tailscale, SSH, or host-wake delay exhausts one publish attempt,
+the MCP terminates the entire rsync/ssh process group and retries once by
+default. This keeps the synchronous ordering guarantee without leaving an
+orphaned transfer that may complete after the tool already reported failure.
+
 ## Verification
 
 - Python MCP tests: `95 passed`.
@@ -53,3 +58,30 @@ available as a rollback mechanism.
 - A live short TTS request published the same SHA-256 on mini and MacBook.
 - MacBook `5061` log returned HTTP 200 for the new filename.
 - Device `started_ms` advanced and the microphone resumed recording afterward.
+
+## Follow-up: bounded publish timeout (2026-08-24)
+
+At 00:36 JST, a later speech request generated a valid 405,636-byte WAV on the
+mini but returned `audio publish timed out after 20s`. The MacBook HTTP log had
+no matching request, so this failure happened before `/play` and was separate
+from both the firmware download recovery and the earlier 404 race. A later
+publish over the same route completed in 3.77 seconds with matching SHA-256
+hashes on both hosts, supporting a transient SSH/Tailscale or host-wake delay
+rather than a persistent path or credential failure.
+
+The publisher now gives transient failures one bounded retry. Each attempt runs
+rsync and ssh in a new process group; timeout cleanup terminates that entire
+group before the retry, preventing a late orphan transfer from violating the
+publish-before-play result. The retry count is configurable and clamped to at
+most three.
+
+Follow-up verification:
+
+- Full Python suite: `104 passed`.
+- Focused publish tests cover cleanup, retry success, and retry exhaustion.
+- Ruff and Pyright passed.
+- Publish-only live check: 405,636 bytes, matching SHA-256 across mini and
+  MacBook; no device playback was triggered.
+- MCP LaunchDaemon restarted with `publish_attempts=2`.
+- The old `audio-push` job/process count is zero; one MacBook audio wait server
+  remains active.

--- a/docs/remote-wav-publish-race-troubleshooting-2026-08-23.md
+++ b/docs/remote-wav-publish-race-troubleshooting-2026-08-23.md
@@ -42,7 +42,7 @@ current WAV and waits for successful completion before sending `/play`. Rsync's
 normal temporary-file rename keeps the destination atomic. Publication has a
 bounded timeout and failures are returned before any playback request is sent.
 
-The old `xyz.migratorybird.audio-push` polling LaunchAgent is disabled in the
+The old `<your-reverse-dns>.audio-push` polling LaunchAgent is disabled in the
 two-host deployment to avoid duplicate concurrent transfers. Its script remains
 available as a rollback mechanism.
 

--- a/docs/touch-sensor-camera-i2c-troubleshooting-2026-08-30.md
+++ b/docs/touch-sensor-camera-i2c-troubleshooting-2026-08-30.md
@@ -1,0 +1,99 @@
+# Touch Strip and Camera I2C Handoff
+
+## Symptom
+
+The top three-zone touch strip works in the official Stack-chan examples but
+does not produce events in this firmware, or it stops working after a camera
+snapshot. ENV readings may also fail after camera initialization.
+
+## Root Cause
+
+On M5Stack CoreS3, the GC0308 camera SCCB interface and the internal I2C bus
+both use GPIO 11/12. The Si12T touch controller is on the internal bus at
+address `0x68`. Keeping the camera initialized permanently releases the bus
+owned by M5Unified, so touch and other internal I2C clients cannot coexist with
+that camera lifecycle.
+
+This is a bus-ownership problem, not a touch-gesture parsing problem.
+
+## Implementation Contract
+
+1. Touch owns the internal I2C bus during normal operation.
+2. `GET /snapshot` suspends touch and releases `M5.In_I2C` immediately before
+   camera initialization. If release fails, camera startup is aborted and the
+   firmware attempts to restore the internal bus instead of driving both bus
+   owners at once.
+3. The camera captures RGB565, converts it to JPEG, and is deinitialized in the
+   same request.
+4. Every camera exit path calls `M5.In_I2C.begin()`, probes `0x68`, and reruns
+   `M5StackChan.TouchSensor.begin()`.
+5. A snapshot is reported as failed if the internal bus cannot be restored, or
+   if a touch controller that was present before capture disappears afterward.
+   A device that never had a detectable Si12T can still use the camera.
+   `GET /touch/status` increments `resume_failure_count` when an expected
+   recovery fails, so the failure is visible remotely. After a transient
+   failure, the main loop retries the internal-bus and touch-controller setup
+   every two seconds instead of leaving touch disabled until another snapshot
+   or reboot.
+
+The touch behavior follows the official Stack-chan pattern: opposite-direction
+swipes within 1500 ms count as petting. The local response is deliberately
+non-blocking and does not enqueue audio or make a network request.
+
+A short tap has a separate local behavior: it starts a forced microphone
+recording and stores the finished WAV with `source=touch`. The host voice bridge
+is responsible for ASR and frontend delivery. It bypasses wake-word filtering
+only for this explicit source and renders the prompt as
+`[Stack-chan语音输入] （触摸）<transcript>`; ordinary ambient recordings keep
+the existing wake-word requirement.
+
+The same bridge observes the monotonic `touch_pet_count` returned by
+`GET /audio/status`. The first value after bridge startup is only a baseline;
+each later increment queues one `[Stack-chan触摸]` prompt to the frontend. The
+bridge drains at most four prompts per poll and retains a bounded backlog of 32
+to absorb ordinary host stalls without allowing a corrupted counter jump to
+flood the frontend. A counter reset after firmware reboot is rebaselined instead
+of replayed. Local happy-face and head-shake behavior remains unchanged.
+
+## Host Verification
+
+```bash
+cd firmware
+pio test -e native
+pio run -e m5stack-cores3
+pio check -e m5stack-cores3 --severity=high --fail-on-defect=high
+```
+
+## Device Regression Checklist
+
+After flashing, run these checks in order:
+
+1. Call `GET /touch/status`; expect `available: true`, `suspended: false`, and
+   `resume_failure_count: 0`.
+2. Touch each of the front, middle, and back zones. Their corresponding
+   intensity should briefly become nonzero.
+3. Tap once; the face should switch to listening and `last_event` should become
+   `recording_started`. Speak without a wake word, then pause. `/audio/status`
+   should become ready with `source: touch`.
+4. Swipe in one direction; `last_event` should become `swipe_forward` or
+   `swipe_backward`.
+5. Swipe back in the opposite direction within 1500 ms. Stack-chan should show
+   the happy face and shake its head; `pet_count` should increment.
+6. Call `GET /snapshot` and verify that a JPEG is returned.
+7. Repeat steps 1-5 after the snapshot. Touch must still respond and
+   `resume_failure_count` must remain zero.
+8. Call `GET /env` after the snapshot and verify that its previously available
+   sensors still return readings.
+9. Exercise microphone recording and audio playback once. Touch gestures must
+   not interrupt either path; a pet detected while audio is busy increments
+   `suppressed_pet_count` instead.
+10. Repeat snapshots and touch checks at least five times to catch lifecycle
+   leaks that a single pass misses.
+
+## Official References
+
+- [StackChan-BSP touch example](https://github.com/m5stack/StackChan-BSP/blob/main/examples/TouchSensor/TouchSensor.ino)
+- [StackChan-BSP touch sensor class](https://github.com/m5stack/StackChan-BSP/blob/main/src/utils/touch_sensor/touch_sensor.cpp)
+- [M5CoreS3 GC0308 bus release](https://github.com/m5stack/M5CoreS3/blob/main/src/utility/GC0308.cpp)
+- [Upstream Stack-chan camera lifecycle](https://github.com/stack-chan/stack-chan/blob/develop/firmware/host/app/runtime-camera.ts)
+- [Upstream Stack-chan petting behavior](https://github.com/stack-chan/stack-chan/blob/develop/firmware/host/app/default-behavior/on-context-created.ts)

--- a/docs/voice-bridge-duplicate-consumer-troubleshooting-2026-08-10.md
+++ b/docs/voice-bridge-duplicate-consumer-troubleshooting-2026-08-10.md
@@ -1,0 +1,49 @@
+# Voice bridge duplicate consumer troubleshooting (2026-08-10)
+
+## Symptom
+
+Physical Stack-chan wake phrases became intermittent after the host services were
+reloaded. Some recordings transcribed correctly but failed to reach the frontend;
+others produced empty or low-quality transcripts.
+
+## Evidence
+
+- Two long-running `stackchan_voice_bridge.py` processes were present. One had
+  started on 2026-07-28; the system LaunchDaemon started another on 2026-08-10.
+- Both processes wrote to the same `stackchan-voice-bridge.log` and polled the
+  same device.
+- `GET /audio` consumes and clears Stack-chan's current recording, so concurrent
+  pollers race for each recording.
+- The older process predated relay-token refresh support. Log entries showed valid
+  wake-word matches followed by HTTP 401 responses from the frontend wake route.
+- Binding the separate upload receiver to `0.0.0.0` only changed reachability. It
+  did not resample or otherwise transform audio.
+
+## Root cause
+
+The migration left a manually started voice bridge alive while launchd also owned
+a bridge. PID-file checks in `start-voice-bridge.sh` did not protect direct Python
+launches or the system LaunchDaemon path.
+
+## Fix
+
+The stale process was terminated, leaving the system LaunchDaemon as the sole
+consumer. The Python bridge now takes a target-specific host-local advisory lock
+under the current user's `Library/Caches/stackchan/` directory before any mode
+that can consume `GET /audio`. A second long-running instance remains in standby
+and can take over after the active owner exits, but it cannot read recordings
+concurrently. A contending `--once` probe reports `busy` and exits immediately;
+read-only `--dry-run` probes do not take the consumer lock.
+
+## Verification
+
+```sh
+ps -axo pid,ppid,lstart,command | grep stackchan_voice_bridge.py
+curl -sS --max-time 5 http://STACKCHAN_IP/playback/status
+uv run pytest tests/test_mcp_server.py -k voice_bridge
+uv run ruff check scripts/stackchan_voice_bridge.py tests/test_mcp_server.py
+```
+
+At runtime, verify there is one active bridge process, `mic_running` is true, and
+`mic_frame_count` continues increasing. A deliberate second bridge should emit a
+single `standby` event and must not consume `/audio`.

--- a/docs/wav-download-recovery-troubleshooting-2026-08-23.md
+++ b/docs/wav-download-recovery-troubleshooting-2026-08-23.md
@@ -1,0 +1,54 @@
+# WAV Download Recovery Troubleshooting - 2026-08-23
+
+## Symptoms
+
+- One interrupted WAV download could leave the audio pipeline silent.
+- Later speech requests were accepted but never reached playback.
+- A physical power cycle was the only known recovery.
+
+## Investigation
+
+- USB inspection identified the CoreS3 as an Espressif USB Serial/JTAG device
+  at `/dev/cu.usbmodem1101`.
+- The first MacBook checkout was an older firmware tree. Flashing it exposed
+  repository drift because it used stale hard-coded Wi-Fi and PNG faces, while
+  the deployed device had NVS Wi-Fi and GIF faces.
+- The active source was recovered from the Mac mini checkout at
+  `/Users/koke/Projects/stackchan-mcp`. A full 16 MB flash backup was saved on
+  the MacBook before restoring the active firmware line.
+- Source inspection found that `downloadTask()` used non-blocking completion
+  queue writes. If the success or failure result was dropped,
+  `s_downloadInFlight` remained true forever.
+
+## Root Cause
+
+The completion event both carries the downloaded buffer and releases the
+single in-flight download state. Dropping that event permanently prevents later
+WAV downloads from starting. The HTTP reader had an inactivity timeout but no
+absolute transfer deadline or independent final recovery path.
+
+## Fix
+
+- Use a one-slot completion queue matching the one-download-in-flight invariant.
+- Block the worker until the main loop accepts the one completion event.
+- Fail initialization cleanly if either queue or the worker task is unavailable.
+- Add a 10-second connect/inactivity timeout and a 30-second body-read limit.
+- Expose `download_age_ms` and `download_watchdog_ms` through playback status.
+- Restart automatically after 60 seconds only if the normal recovery path fails.
+
+## Verification
+
+- `cd firmware && pio run -e m5stack-cores3`: passed; RAM 36.1%, flash 21.6%.
+- Flashed the live CoreS3 and confirmed NVS Wi-Fi, GIF faces, HTTP, microphone,
+  speaker, and servo services were healthy.
+- Served a WAV response declaring 12,044 bytes but closed after 6,022 bytes.
+  Firmware logged the incomplete read and returned to
+  `download_in_flight=false` with `download_age_ms=0`.
+- Without restarting or unplugging, served the complete 12,044-byte WAV. It
+  downloaded and played, released its buffer, and resumed the microphone.
+
+## Recovery Artifact
+
+The MacBook recovery directory contains the full post-incident flash backup and
+the verified firmware images used for the restore. It is intentionally outside
+the repository because it may contain device-local NVS state.

--- a/docs/wav-download-recovery-troubleshooting-2026-08-23.md
+++ b/docs/wav-download-recovery-troubleshooting-2026-08-23.md
@@ -14,7 +14,7 @@
   repository drift because it used stale hard-coded Wi-Fi and PNG faces, while
   the deployed device had NVS Wi-Fi and GIF faces.
 - The active source was recovered from the Mac mini checkout at
-  `/Users/koke/Projects/stackchan-mcp`. A full 16 MB flash backup was saved on
+  `~/Projects/stackchan-mcp`. A full 16 MB flash backup was saved on
   the MacBook before restoring the active firmware line.
 - Source inspection found that `downloadTask()` used non-blocking completion
   queue writes. If the success or failure result was dropped,

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -3,7 +3,7 @@
 **M5Stack CoreS3 firmware for the Stack-chan MCP robot**
 
 PC/Mac 上の MCP サーバーや補助ツールから、M5Stack CoreS3 上の Stack-chan を HTTP で制御するためのファームウェアです。
-音声再生、録音取得、表情表示、サーボ動作、カメラ撮影、環境センサー取得を担当します。
+音声再生、録音取得、表情表示、サーボ動作、トップのタッチストリップ、カメラ撮影、環境センサー取得を担当します。
 
 ---
 
@@ -12,7 +12,8 @@ PC/Mac 上の MCP サーバーや補助ツールから、M5Stack CoreS3 上の S
 - **HTTP 音声再生**: `POST /play` で WAV URL を再生、`POST /play/pcm` と TCP PCM ストリームで低遅延 PCM 再生
 - **録音の MCP pull モード**: `POST /mode` で録音状態を初期化し、`GET /audio/status` と `GET /audio` で取得
 - **表情・動作・視覚**: `POST /face`、`POST /move`、`POST /nod`、`POST /shake`、`GET /snapshot`
-- **診断エンドポイント**: `GET /playback/status`、`GET /servo/status`、`GET /env`、`GET /env/debug`
+- **タッチ操作**: タップでウェイクワード不要の録音を開始し、往復スワイプで撫で動作（5 秒間の happy 表情 + 首振り）
+- **診断エンドポイント**: `GET /playback/status`、`GET /servo/status`、`GET /touch/status`、`GET /env`、`GET /env/debug`
 - **Arduino / PlatformIO ベース**: CoreS3 向けの C++ ファームウェア
 
 ---
@@ -65,15 +66,20 @@ pio device monitor
 | `POST /play` | WAV URL を受け取って再生 |
 | `POST /play/pcm` | 24kHz mono s16le PCM を受け取って再生またはキュー投入 |
 | `POST /mode` | 録音状態を初期化 (`mode` は `mcp` のみ) |
-| `GET /audio/status` | 録音完了フラグを確認 |
+| `GET /audio/status` | 録音完了フラグと録音元 (`voice` / `touch`) を確認 |
 | `GET /audio` | 録音済み WAV を取得 |
 | `POST /move` / `POST /home` / `POST /nod` / `POST /shake` | 頭の向きとジェスチャー制御 |
 | `POST /face` / `GET /face` | 表情を変更 / 確認 |
 | `GET /snapshot` | カメラ JPEG を取得 |
 | `GET /playback/status` | 音声再生・PCM キュー診断 |
 | `GET /servo/status` | サーボ状態診断 |
+| `GET /touch/status` | タッチ強度、録音開始回数、直近ジェスチャー、カメラ後の I2C 復帰失敗回数 |
 | `GET /env` | 温度・湿度・気圧を取得 |
 | `GET /env/debug` | 環境センサーの診断情報を取得 |
+
+CoreS3 のカメラ SCCB と内部 I2C（タッチ・環境センサー）は GPIO 11/12 を共有します。
+そのためカメラは常時起動せず、`GET /snapshot` の間だけタッチを停止して使用し、
+成功・失敗のどちらでも内部 I2C とタッチドライバーを復帰させます。
 
 ---
 

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -29,8 +29,8 @@ build_flags =
 lib_deps =
 	m5stack/M5Unified@0.2.15
 	bblanchon/ArduinoJson@7.4.3
-	M5GFX@0.2.21
-	m5stack/StackChan-BSP@1.1.0
+	https://github.com/m5stack/M5GFX.git#0.2.21
+	https://github.com/m5stack/StackChan-BSP.git#0addef4cf51d9f26c86ac553f0fdd2832d19a5e5
 	bitbank2/AnimatedGIF@2.2.3
 lib_ldf_mode = deep
 check_tool = cppcheck

--- a/firmware/platformio.ini
+++ b/firmware/platformio.ini
@@ -29,7 +29,8 @@ build_flags =
 lib_deps =
 	m5stack/M5Unified@0.2.15
 	bblanchon/ArduinoJson@7.4.3
-	https://github.com/m5stack/M5GFX.git#0.2.21
+	; M5GFX 0.2.21 (pinned to the tag's commit SHA)
+	https://github.com/m5stack/M5GFX.git#5268353cffabd2925b87ed9bcc05ded4e22cc3d1
 	https://github.com/m5stack/StackChan-BSP.git#0addef4cf51d9f26c86ac553f0fdd2832d19a5e5
 	bitbank2/AnimatedGIF@2.2.3
 lib_ldf_mode = deep

--- a/firmware/src/audio_download.cpp
+++ b/firmware/src/audio_download.cpp
@@ -4,8 +4,9 @@
 #include "audio_download.h"
 #include "wav_parser.h"
 
-#define DOWNLOAD_TIMEOUT_MS   10000
-#define MAX_WAV_BYTES         (4 * 1024 * 1024)
+#define DOWNLOAD_TIMEOUT_MS       10000
+#define DOWNLOAD_TOTAL_TIMEOUT_MS 30000
+#define MAX_WAV_BYTES             (4 * 1024 * 1024)
 
 bool downloadVoice(const String& url, uint8_t** outData, size_t* outSize) {
     HTTPClient http;
@@ -15,6 +16,7 @@ bool downloadVoice(const String& url, uint8_t** outData, size_t* outSize) {
     *outSize = 0;
 
     http.begin(url);
+    http.setConnectTimeout(DOWNLOAD_TIMEOUT_MS);
     http.setTimeout(DOWNLOAD_TIMEOUT_MS);
     int httpCode = http.GET();
 
@@ -40,8 +42,13 @@ bool downloadVoice(const String& url, uint8_t** outData, size_t* outSize) {
 
     WiFiClient* stream = http.getStreamPtr();
     size_t bytesRead = 0;
+    unsigned long downloadStartedMs = millis();
     unsigned long lastProgressMs = millis();
     while (bytesRead < (size_t)len) {
+        if (millis() - downloadStartedMs > DOWNLOAD_TOTAL_TIMEOUT_MS) {
+            Serial.println("[DOWNLOAD] Total timeout");
+            break;
+        }
         size_t available = stream->available();
         if (available) {
             size_t toRead = min(available, (size_t)(len - bytesRead));

--- a/firmware/src/camera_service.cpp
+++ b/firmware/src/camera_service.cpp
@@ -1,4 +1,5 @@
 #include "camera_service.h"
+#include "touch_service.h"
 #include "esp_camera.h"
 #include "img_converters.h"
 #include <M5Unified.h>
@@ -25,10 +26,7 @@
 
 static bool cameraReady = false;
 
-bool initCamera() {
-    // Release M5Unified's internal I2C bus — it shares pins 11/12 with camera SCCB
-    M5.In_I2C.release();
-
+static bool initCamera() {
     camera_config_t config;
     memset(&config, 0, sizeof(config));
 
@@ -74,45 +72,71 @@ bool initCamera() {
     return true;
 }
 
-bool captureJpeg(uint8_t** outBuf, size_t* outLen, int quality) {
-    if (!cameraReady) {
-        Serial.println("[CAM] Not initialized");
-        return false;
-    }
-
-    // With CAMERA_GRAB_WHEN_EMPTY, the driver captures one frame immediately after
-    // esp_camera_fb_return(). That frame sits in the DMA buffer until the next
-    // fb_get() — potentially minutes later. Discard it to force a fresh capture.
-    camera_fb_t* stale = esp_camera_fb_get();
-    if (!stale) {
-        Serial.println("[CAM] Stale flush failed");
-        return false;
-    }
-    esp_camera_fb_return(stale);
-
-    camera_fb_t* fb = esp_camera_fb_get();
-    if (!fb) {
-        Serial.println("[CAM] Capture failed");
-        return false;
-    }
-
-    // Convert RGB565 to JPEG
-    bool ok = frame2jpg(fb, quality, outBuf, outLen);
-    esp_camera_fb_return(fb);
-
-    if (!ok) {
-        Serial.println("[CAM] JPEG conversion failed");
-        return false;
-    }
-
-    Serial.printf("[CAM] Captured JPEG: %u bytes\n", (unsigned)*outLen);
-    return true;
-}
-
-void deinitCamera() {
+static void deinitCamera() {
     if (cameraReady) {
         esp_camera_deinit();
         cameraReady = false;
         Serial.println("[CAM] Deinitialized");
     }
+}
+
+bool captureJpeg(uint8_t** outBuf, size_t* outLen, int quality) {
+    if (!outBuf || !outLen) {
+        return false;
+    }
+    *outBuf = nullptr;
+    *outLen = 0;
+
+    // GC0308 SCCB and M5.In_I2C both use GPIO 11/12. Keep the camera lazy so
+    // touch and environmental sensors own the bus between snapshots.
+    suspendTouchService();
+    const bool busReleased = M5.In_I2C.release();
+    if (!busReleased) {
+        Serial.println("[CAM] Internal I2C release failed; camera start aborted");
+        if (!resumeTouchService()) {
+            Serial.println("[CAM] Internal I2C also failed to recover after release failure");
+        }
+        return false;
+    }
+
+    bool captureOk = false;
+    if (initCamera()) {
+        // With CAMERA_GRAB_WHEN_EMPTY, the driver captures one frame immediately
+        // after esp_camera_fb_return(). Discard it to force a fresh capture.
+        camera_fb_t* stale = esp_camera_fb_get();
+        if (!stale) {
+            Serial.println("[CAM] Stale flush failed");
+        } else {
+            esp_camera_fb_return(stale);
+
+            camera_fb_t* fb = esp_camera_fb_get();
+            if (!fb) {
+                Serial.println("[CAM] Capture failed");
+            } else {
+                captureOk = frame2jpg(fb, quality, outBuf, outLen);
+                esp_camera_fb_return(fb);
+                if (!captureOk) {
+                    Serial.println("[CAM] JPEG conversion failed");
+                }
+            }
+        }
+    }
+
+    deinitCamera();
+    const bool touchRestored = resumeTouchService();
+
+    if (!captureOk || !touchRestored) {
+        if (*outBuf) {
+            free(*outBuf);
+            *outBuf = nullptr;
+        }
+        *outLen = 0;
+        if (!touchRestored) {
+            Serial.println("[CAM] Snapshot rejected because internal I2C/touch did not recover");
+        }
+        return false;
+    }
+
+    Serial.printf("[CAM] Captured JPEG: %u bytes\n", (unsigned)*outLen);
+    return true;
 }

--- a/firmware/src/camera_service.h
+++ b/firmware/src/camera_service.h
@@ -10,15 +10,10 @@
  * Captures RGB565 frames and converts to JPEG
  */
 
-// Initialize camera (call in setup after M5.begin)
-bool initCamera();
-
-// Capture a JPEG snapshot
+// Capture a JPEG snapshot. Camera SCCB and the internal I2C bus share GPIO
+// 11/12, so captureJpeg owns the complete camera/touch handoff lifecycle.
 // Returns true on success, sets outBuf and outLen
 // Caller must free(*outBuf) after use
 bool captureJpeg(uint8_t** outBuf, size_t* outLen, int quality = 80);
-
-// Deinitialize camera (to free DMA/I2C resources if needed)
-void deinitCamera();
 
 #endif

--- a/firmware/src/face_service.cpp
+++ b/firmware/src/face_service.cpp
@@ -19,6 +19,7 @@ static int            gif_src_height     = 0;
 // ── Face tracking ──────────────────────────────────────────────────────────
 static WhaleFace currentFace = WHALE_CALM;
 static bool      isTalking   = false;
+static uint32_t  faceCommandRevision = 0;
 
 // ── GIF asset table ────────────────────────────────────────────────────────
 struct GifAsset { const uint8_t* data; size_t len; };
@@ -209,6 +210,7 @@ void setFaceExpression(FaceExpression expr) {
             break;
     }
 
+    ++faceCommandRevision;
     if (target != currentFace) {
         switchToFace(target);
     }
@@ -223,9 +225,14 @@ void setMouthOpen(float ratio) {
 
 void setWhaleFace(WhaleFace face) {
     isTalking = false;
+    ++faceCommandRevision;
     switchToFace(face);
 }
 
 const char* getCurrentFaceName() {
     return whaleFaceName(currentFace);
+}
+
+uint32_t getFaceCommandRevision() {
+    return faceCommandRevision;
 }

--- a/firmware/src/face_service.cpp
+++ b/firmware/src/face_service.cpp
@@ -215,13 +215,10 @@ void setFaceExpression(FaceExpression expr) {
 }
 
 void setMouthOpen(float ratio) {
-    // Lip sync: toggle between calm and happy during speech.
-    if (!isTalking) return;
-
-    WhaleFace target = (ratio > 0.15f) ? WHALE_HAPPY : WHALE_CALM;
-    if (target != currentFace) {
-        switchToFace(target);
-    }
+    // Lip sync disabled for AnimatedGIF faces — pixel art has no mouth
+    // animation, and switching GIFs causes visible flicker (close + open + redraw).
+    // Keep the function signature for API compatibility.
+    (void)ratio;
 }
 
 void setWhaleFace(WhaleFace face) {

--- a/firmware/src/face_service.h
+++ b/firmware/src/face_service.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #include "face_names.h"
 
 // Expression types (state-based, used by mic/audio services)
@@ -16,3 +18,6 @@ void setFaceExpression(FaceExpression expr);
 void setMouthOpen(float ratio);  // 0.0~1.0 for lip sync
 void setWhaleFace(WhaleFace face);  // Direct face control
 const char* getCurrentFaceName();
+// Advances on every face command, including a same-face reassertion. This lets
+// temporary effects avoid restoring over a newer owner's explicit command.
+uint32_t getFaceCommandRevision();

--- a/firmware/src/http_server.cpp
+++ b/firmware/src/http_server.cpp
@@ -14,6 +14,7 @@
 #include "audio_gate.h"
 #include "pcm_stream_service.h"
 #include "env_service.h"
+#include "touch_service.h"
 
 static WebServer server(80);
 
@@ -215,12 +216,17 @@ static void handleMode() {
 
 // ────────────────────────────────────────────
 // GET /audio/status
-// → {"ready": true/false, "mode": "mcp"}
+// → Recording state plus the monotonic touch-petting event counter.
 // ────────────────────────────────────────────
 static void handleAudioStatus() {
+    TouchRuntimeStatus touch = getTouchRuntimeStatus();
     String body = "{\"ready\":";
     body += hasLastRecording() ? "true" : "false";
-    body += ",\"mode\":\"mcp\"}";
+    body += ",\"mode\":\"mcp\",\"source\":\"";
+    body += recordingSourceName(getLastRecordingSource());
+    body += "\",\"touch_pet_count\":";
+    body += String(touch.petCount);
+    body += "}";
     server.send(200, "application/json", body);
 }
 
@@ -347,6 +353,33 @@ static void handleServoStatus() {
     JsonObject pitch = doc["pitch"].to<JsonObject>();
     addFeedback(yaw, status.yaw);
     addFeedback(pitch, status.pitch);
+
+    String body;
+    serializeJson(doc, body);
+    server.send(200, "application/json", body);
+}
+
+// ────────────────────────────────────────────
+// GET /touch/status
+// → Si12T touch-strip state and camera handoff diagnostics
+// ────────────────────────────────────────────
+static void handleTouchStatus() {
+    TouchRuntimeStatus status = getTouchRuntimeStatus();
+    JsonDocument doc;
+    doc["available"] = status.available;
+    doc["suspended"] = status.suspended;
+    doc["petting_active"] = status.pettingActive;
+    JsonArray intensities = doc["intensities"].to<JsonArray>();
+    for (uint8_t intensity : status.intensities) {
+        intensities.add(intensity);
+    }
+    doc["last_event"] = status.lastEvent;
+    doc["last_event_ms"] = status.lastEventMs;
+    doc["pet_count"] = status.petCount;
+    doc["suppressed_pet_count"] = status.suppressedPetCount;
+    doc["record_request_count"] = status.recordRequestCount;
+    doc["record_start_failure_count"] = status.recordStartFailureCount;
+    doc["resume_failure_count"] = status.resumeFailureCount;
 
     String body;
     serializeJson(doc, body);
@@ -625,6 +658,7 @@ void initHttpServer() {
     server.on("/nod",          HTTP_POST, handleNod);
     server.on("/shake",        HTTP_POST, handleShake);
     server.on("/servo/status", HTTP_GET,  handleServoStatus);
+    server.on("/touch/status", HTTP_GET,  handleTouchStatus);
     server.on("/playback/status", HTTP_GET, handlePlaybackStatus);
     server.on("/snapshot",     HTTP_GET,  handleSnapshot);
     server.on("/face",         HTTP_POST, handleFace);

--- a/firmware/src/http_server.cpp
+++ b/firmware/src/http_server.cpp
@@ -362,6 +362,7 @@ static void handlePlaybackStatus() {
     PcmStreamStatus stream = getPcmStreamStatus();
     ServoStatus servo = getServoStatus();
     AudioGateStatus audio = getAudioGateStatus();
+    MicRuntimeStatus mic = getMicRuntimeStatus();
 
     JsonDocument doc;
     bool streamActive = stream.active || stream.playing;
@@ -408,6 +409,15 @@ static void handlePlaybackStatus() {
     doc["started_ms"] = playback.startedMs;
     doc["deadline_ms"] = playback.deadlineMs;
     doc["mic_state"] = getMicStateName();
+    doc["mic_enabled"] = mic.enabled;
+    doc["mic_running"] = mic.running;
+    doc["mic_last_rms"] = mic.lastRms;
+    doc["mic_recent_peak_rms"] = mic.recentPeakRms;
+    doc["mic_last_frame_ms"] = mic.lastFrameMs;
+    doc["mic_frame_count"] = mic.frameCount;
+    doc["mic_record_failure_count"] = mic.recordFailureCount;
+    doc["mic_trigger_count"] = mic.triggerCount;
+    doc["mic_stored_recording_count"] = mic.storedRecordingCount;
     doc["mic_resume_requested"] = playback.micResumeRequested;
     doc["servo_ready"] = servo.ready;
     doc["gesture_active"] = servo.gestureActive;

--- a/firmware/src/http_server.cpp
+++ b/firmware/src/http_server.cpp
@@ -406,6 +406,8 @@ static void handlePlaybackStatus() {
     doc["audio_queue_depth"] = playback.audioQueueDepth;
     doc["download_queue_depth"] = playback.downloadQueueDepth;
     doc["download_in_flight"] = playback.downloadInFlight;
+    doc["download_age_ms"] = playback.downloadAgeMs;
+    doc["download_watchdog_ms"] = playback.downloadWatchdogMs;
     doc["started_ms"] = playback.startedMs;
     doc["deadline_ms"] = playback.deadlineMs;
     doc["mic_state"] = getMicStateName();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -8,11 +8,12 @@
 #include "config_loader.h"
 #include "mic_service.h"
 #include "wifi_manager.h"
+#include "wifi_portal.h"
 #include "playback_service.h"
 #include "pcm_stream_service.h"
 #include "face_service.h"
 #include "servo_service.h"
-#include "camera_service.h"
+#include "touch_service.h"
 #include "audio_gate.h"
 #include "env_service.h"
 
@@ -22,8 +23,17 @@ void setup() {
 
     M5StackChan.begin();
     M5.Display.setBrightness(DISPLAY_BRIGHTNESS);
-    initAudioGate();
 
+    // ── BtnA チェック：開機時に押したまま → 強制配网模式 ──────────────────
+    // M5.update() を一度呼んでボタン状態を読み取る
+    M5.update();
+    if (M5.BtnA.isPressed()) {
+        Serial.println("[SETUP] BtnA held at boot -> forcing WiFi portal");
+        // portal は内部で ESP.restart() するので戻らない
+        runWifiPortal();
+    }
+
+    initAudioGate();
     initFace();
 
     Serial.println("\n=== Stack-chan firmware ===");
@@ -40,23 +50,31 @@ void setup() {
         Serial.println("[WARN] Servo init failed - head movement disabled");
     }
 
-    if (!initCamera()) {
-        Serial.println("[WARN] Camera init failed - vision disabled");
+    if (!initTouchService()) {
+        Serial.println("[WARN] Touch sensor unavailable");
     }
     if (!initEnvService()) {
         Serial.println("[WARN] Env sensor init failed - no temperature/humidity/pressure");
     }
 
+    // ── WiFi 接続シーケンス ────────────────────────────────────────────────
+    // connectWiFi() が false を返したら全部失敗 → 配网 portal に入る
+    if (!connectWiFi()) {
+        Serial.println("[SETUP] WiFi failed -> starting captive portal");
+        // portal は内部で ESP.restart() するので戻らない
+        runWifiPortal();
+    }
 
-    connectWiFi();
     initPlayback();
     initPcmStreamService();
     initHttpServer();
 }
+
 void loop() {
     static uint32_t lastMicResumeAttemptMs = 0;
 
     M5StackChan.update();
+    updateTouchService();
     handleHttpServer();
     serviceWiFi();
     updateServoGesture();

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -54,6 +54,8 @@ void setup() {
     initHttpServer();
 }
 void loop() {
+    static uint32_t lastMicResumeAttemptMs = 0;
+
     M5StackChan.update();
     handleHttpServer();
     serviceWiFi();
@@ -62,14 +64,24 @@ void loop() {
     updatePlayback();
     updateMicrophone();
 
+    // Playback can stop the microphone before the normal completion path has
+    // a chance to request a resume. Keep the request latched until begin()
+    // succeeds so one transient failure cannot leave the device deaf.
+    if (!M5.Mic.isRunning()) {
+        requestMicResume();
+    }
+
     // マイク再開（完了検知より前に置く）
     if (shouldResumeMic()) {
-        clearMicResumeRequest();
-        if (!M5.Mic.isRunning()) {
+        if (M5.Mic.isRunning()) {
+            clearMicResumeRequest();
+        } else if (millis() - lastMicResumeAttemptMs >= 1000) {
+            lastMicResumeAttemptMs = millis();
             if (initMicrophone()) {
+                clearMicResumeRequest();
                 Serial.println("[MIC] Mic resumed after playback");
             } else {
-                Serial.println("[MIC] Mic resume failed");
+                Serial.println("[MIC] Mic resume failed; retrying");
             }
         }
     }

--- a/firmware/src/mic_service.cpp
+++ b/firmware/src/mic_service.cpp
@@ -40,6 +40,14 @@ static size_t recorded_samples = 0;
 static MicState mic_state = MIC_IDLE;
 static uint32_t trigger_start_ms = 0;
 static uint32_t silence_start_ms = 0;
+static float last_rms = 0.0f;
+static float recent_peak_rms = 0.0f;
+static uint32_t peak_window_start_ms = 0;
+static uint32_t last_frame_ms = 0;
+static uint32_t frame_count = 0;
+static uint32_t record_failure_count = 0;
+static uint32_t trigger_count = 0;
+static uint32_t stored_recording_count = 0;
 
 // プリトリガーリングバッファ
 static int16_t pre_trigger_buf[PRE_TRIGGER_BUFFER_SAMPLES];
@@ -65,6 +73,20 @@ const char* getMicStateName() {
         case MIC_SENDING: return "sending";
         default: return "unknown";
     }
+}
+
+MicRuntimeStatus getMicRuntimeStatus() {
+    MicRuntimeStatus status;
+    status.enabled = M5.Mic.isEnabled();
+    status.running = M5.Mic.isRunning();
+    status.lastRms = last_rms;
+    status.recentPeakRms = recent_peak_rms;
+    status.lastFrameMs = last_frame_ms;
+    status.frameCount = frame_count;
+    status.recordFailureCount = record_failure_count;
+    status.triggerCount = trigger_count;
+    status.storedRecordingCount = stored_recording_count;
+    return status;
 }
 
 static bool isValidAudio(int16_t* audio_data, size_t sample_count) {
@@ -158,7 +180,7 @@ bool initMicrophone() {
 }
 
 void updateMicrophone() {
-    if (!M5.Mic.isEnabled()) return;
+    if (!M5.Mic.isEnabled() || !M5.Mic.isRunning()) return;
     if (!record_buffer) return;
     if (isPlaybackActive()) return;
 
@@ -166,11 +188,23 @@ void updateMicrophone() {
     if (!audioGateEnter("mic-record", 0)) return;
     bool recorded = M5.Mic.record(frame, MIC_FRAME_SAMPLES, MIC_SAMPLE_RATE);
     audioGateLeave("mic-record");
-    if (!recorded) return;
+    if (!recorded) {
+        record_failure_count++;
+        return;
+    }
     size_t got = MIC_FRAME_SAMPLES;
 
     float rms = calcRmsNorm(frame, got);
     uint32_t now = millis();
+    last_rms = rms;
+    last_frame_ms = now;
+    frame_count++;
+    if (peak_window_start_ms == 0 || now - peak_window_start_ms >= 2000) {
+        peak_window_start_ms = now;
+        recent_peak_rms = rms;
+    } else if (rms > recent_peak_rms) {
+        recent_peak_rms = rms;
+    }
 
     if (mic_state == MIC_IDLE || mic_state == MIC_TRIGGERING) {
         for (size_t i = 0; i < got; i++) {
@@ -183,6 +217,7 @@ void updateMicrophone() {
     switch (mic_state) {
         case MIC_IDLE:
             if (rms > MIC_TRIGGER_RMS) {
+                trigger_count++;
                 trigger_start_ms = now;
                 mic_state = MIC_TRIGGERING;
             }
@@ -244,6 +279,7 @@ void updateMicrophone() {
 
                 bool ok = storeRecordingForMcp(record_buffer, recorded_samples);
                 Serial.printf("[MIC] Store recording result=%s\n", ok ? "OK" : "NG");
+                if (ok) stored_recording_count++;
                 if (!ok) setFaceExpression(FACE_IDLE);
                 mic_state = MIC_IDLE;
             }

--- a/firmware/src/mic_service.cpp
+++ b/firmware/src/mic_service.cpp
@@ -7,6 +7,7 @@
 #include "http_server.h"
 #include "recording_store.h"
 #include "playback_service.h"
+#include "pcm_stream_service.h"
 #include "audio_gate.h"
 
 enum MicState {
@@ -47,7 +48,14 @@ static uint32_t last_frame_ms = 0;
 static uint32_t frame_count = 0;
 static uint32_t record_failure_count = 0;
 static uint32_t trigger_count = 0;
+static uint32_t touch_trigger_count = 0;
 static uint32_t stored_recording_count = 0;
+static uint32_t recording_started_ms = 0;
+static bool recording_has_voice = false;
+static RecordingSource recording_source = RecordingSource::VOICE;
+
+static constexpr uint32_t TOUCH_INPUT_SETTLE_MS = 250;
+static constexpr uint32_t TOUCH_VOICE_START_TIMEOUT_MS = 4000;
 
 // プリトリガーリングバッファ
 static int16_t pre_trigger_buf[PRE_TRIGGER_BUFFER_SAMPLES];
@@ -63,7 +71,7 @@ static inline float calcRmsNorm(const int16_t* data, size_t n) {
     return sqrtf(sum / (float)n);       
 }
 
-static bool storeRecordingForMcp(int16_t* audio_data, size_t sample_count);
+static bool storeRecordingForMcp(int16_t* audio_data, size_t sample_count, RecordingSource source);
 
 const char* getMicStateName() {
     switch (mic_state) {
@@ -85,23 +93,90 @@ MicRuntimeStatus getMicRuntimeStatus() {
     status.frameCount = frame_count;
     status.recordFailureCount = record_failure_count;
     status.triggerCount = trigger_count;
+    status.touchTriggerCount = touch_trigger_count;
     status.storedRecordingCount = stored_recording_count;
     return status;
 }
 
-static bool isValidAudio(int16_t* audio_data, size_t sample_count) {
+static bool isValidAudio(int16_t* audio_data, size_t sample_count, RecordingSource source) {
     if (sample_count < MIC_MIN_VALID_SAMPLES) {
         Serial.printf("[MIC] Too short (%u samples), discarding\n", (unsigned)sample_count);
         return false;
     }
-    size_t check_samples = MIC_SAMPLE_RATE / 2;
+    const size_t check_samples = MIC_SAMPLE_RATE / 2;
     if (sample_count > check_samples) {
-        float early_rms = calcRmsNorm(audio_data, check_samples);
-        if (early_rms < MIC_VOICE_CONFIRM_RMS) {
-            Serial.printf("[MIC] No voice (early RMS=%.3f), discarding\n", early_rms);
-            return false;
+        if (source == RecordingSource::TOUCH) {
+            float peak_window_rms = 0.0f;
+            for (size_t offset = 0; offset < sample_count; offset += check_samples) {
+                const size_t remaining = sample_count - offset;
+                const size_t window_samples = remaining < check_samples ? remaining : check_samples;
+                const float window_rms = calcRmsNorm(audio_data + offset, window_samples);
+                if (window_rms > peak_window_rms) {
+                    peak_window_rms = window_rms;
+                }
+            }
+            if (peak_window_rms < MIC_VOICE_CONFIRM_RMS) {
+                Serial.printf("[MIC] No voice in touch recording (peak window RMS=%.3f), discarding\n",
+                              peak_window_rms);
+                return false;
+            }
+        } else {
+            const float early_rms = calcRmsNorm(audio_data, check_samples);
+            if (early_rms < MIC_VOICE_CONFIRM_RMS) {
+                Serial.printf("[MIC] No voice (early RMS=%.3f), discarding\n", early_rms);
+                return false;
+            }
         }
     }
+    return true;
+}
+
+static void beginRecording(uint32_t now, RecordingSource source, bool includePreTrigger) {
+    if (includePreTrigger) {
+        if (pre_buf_full) {
+            const size_t older = PRE_TRIGGER_BUFFER_SAMPLES - pre_buf_write;
+            memcpy(record_buffer,
+                   pre_trigger_buf + pre_buf_write,
+                   older * sizeof(int16_t));
+            memcpy(record_buffer + older,
+                   pre_trigger_buf,
+                   pre_buf_write * sizeof(int16_t));
+            recorded_samples = PRE_TRIGGER_BUFFER_SAMPLES;
+        } else {
+            memcpy(record_buffer,
+                   pre_trigger_buf,
+                   pre_buf_write * sizeof(int16_t));
+            recorded_samples = pre_buf_write;
+        }
+    } else {
+        recorded_samples = 0;
+    }
+
+    pre_buf_write = 0;
+    pre_buf_full = false;
+    silence_start_ms = 0;
+    recording_started_ms = now;
+    recording_has_voice = source == RecordingSource::VOICE;
+    recording_source = source;
+    mic_state = MIC_RECORDING;
+    setFaceExpression(FACE_LISTENING);
+    Serial.printf("[MIC] -> RECORDING source=%s pre-buffer=%u samples\n",
+                  recordingSourceName(source), (unsigned)recorded_samples);
+}
+
+bool requestTouchRecording() {
+    const bool canReplaceAmbientTrigger = mic_state == MIC_IDLE || mic_state == MIC_TRIGGERING;
+    if (!record_buffer || !M5.Mic.isEnabled() || !M5.Mic.isRunning() ||
+        isPlaybackActive() || isPcmStreamActive() || !canReplaceAmbientTrigger) {
+        Serial.printf("[MIC] Touch recording rejected: state=%s running=%s playback=%s stream=%s\n",
+                      getMicStateName(), M5.Mic.isRunning() ? "yes" : "no",
+                      isPlaybackActive() ? "yes" : "no",
+                      isPcmStreamActive() ? "yes" : "no");
+        return false;
+    }
+
+    ++touch_trigger_count;
+    beginRecording(millis(), RecordingSource::TOUCH, false);
     return true;
 }
 
@@ -226,28 +301,7 @@ void updateMicrophone() {
         case MIC_TRIGGERING:
             if (rms > MIC_TRIGGER_RMS) {
                 if (now - trigger_start_ms >= MIC_TRIGGER_HOLD_MS) {
-                    if (pre_buf_full) {
-                        size_t older = PRE_TRIGGER_BUFFER_SAMPLES - pre_buf_write;
-                        memcpy(record_buffer,
-                               pre_trigger_buf + pre_buf_write,
-                               older * sizeof(int16_t));
-                        memcpy(record_buffer + older,
-                               pre_trigger_buf,
-                               pre_buf_write * sizeof(int16_t));
-                        recorded_samples = PRE_TRIGGER_BUFFER_SAMPLES;
-                    } else {
-                        memcpy(record_buffer,
-                               pre_trigger_buf,
-                               pre_buf_write * sizeof(int16_t));
-                        recorded_samples = pre_buf_write;
-                    }
-                    pre_buf_write = 0;
-                    pre_buf_full  = false;
-                    silence_start_ms = 0;
-                    mic_state = MIC_RECORDING;
-                    setFaceExpression(FACE_LISTENING);
-                    Serial.printf("[MIC] Triggered -> RECORDING (pre-buffer: %u samples)\n",
-                                  (unsigned)recorded_samples);
+                    beginRecording(now, RecordingSource::VOICE, true);
                 }
             } else {
                 mic_state = MIC_IDLE;
@@ -255,29 +309,43 @@ void updateMicrophone() {
             break;
 
         case MIC_RECORDING: {
-            size_t remain = max_samples - recorded_samples;
-            size_t to_copy = (got < remain) ? got : remain;
-            memcpy(record_buffer + recorded_samples, frame, to_copy * sizeof(int16_t));
-            recorded_samples += to_copy;
+            const bool touch_settling = recording_source == RecordingSource::TOUCH &&
+                                        now - recording_started_ms < TOUCH_INPUT_SETTLE_MS;
+            if (!touch_settling) {
+                size_t remain = max_samples - recorded_samples;
+                size_t to_copy = (got < remain) ? got : remain;
+                memcpy(record_buffer + recorded_samples, frame, to_copy * sizeof(int16_t));
+                recorded_samples += to_copy;
+            }
 
             bool maxed = (recorded_samples >= max_samples);
+            if (!touch_settling && rms >= MIC_VOICE_CONFIRM_RMS) {
+                recording_has_voice = true;
+            }
 
-            if (rms < MIC_SILENCE_RMS) {
-                if (silence_start_ms == 0) silence_start_ms = now;
-            } else {
-                silence_start_ms = 0;
+            if (recording_has_voice) {
+                if (rms < MIC_SILENCE_RMS) {
+                    if (silence_start_ms == 0) silence_start_ms = now;
+                } else {
+                    silence_start_ms = 0;
+                }
             }
 
             bool silent_end = (silence_start_ms != 0 &&
                                (now - silence_start_ms) >= MIC_SILENCE_HOLD_MS);
+            const bool touch_start_timeout =
+                recording_source == RecordingSource::TOUCH && !recording_has_voice &&
+                now - recording_started_ms >= TOUCH_VOICE_START_TIMEOUT_MS;
 
-            if (maxed || silent_end) {
+            if (maxed || silent_end || touch_start_timeout) {
                 mic_state = MIC_SENDING;
-                Serial.printf("[MIC] Record end: samples=%u reason=%s\n",
-                              (unsigned)recorded_samples, maxed ? "max" : "silence");
+                const char* reason = maxed ? "max" : (silent_end ? "silence" : "touch_start_timeout");
+                Serial.printf("[MIC] Record end: samples=%u reason=%s source=%s\n",
+                              (unsigned)recorded_samples, reason, recordingSourceName(recording_source));
                 setFaceExpression(FACE_THINKING);
 
-                bool ok = storeRecordingForMcp(record_buffer, recorded_samples);
+                bool ok = !touch_start_timeout &&
+                          storeRecordingForMcp(record_buffer, recorded_samples, recording_source);
                 Serial.printf("[MIC] Store recording result=%s\n", ok ? "OK" : "NG");
                 if (ok) stored_recording_count++;
                 if (!ok) setFaceExpression(FACE_IDLE);
@@ -291,8 +359,8 @@ void updateMicrophone() {
     }
 }
 
-static bool storeRecordingForMcp(int16_t* audio_data, size_t sample_count) {
-    if (!isValidAudio(audio_data, sample_count)) return false;
+static bool storeRecordingForMcp(int16_t* audio_data, size_t sample_count, RecordingSource source) {
+    if (!isValidAudio(audio_data, sample_count, source)) return false;
 
     size_t wav_size = 0;
     uint8_t* wav = buildWav(audio_data, sample_count, wav_size);
@@ -301,8 +369,11 @@ static bool storeRecordingForMcp(int16_t* audio_data, size_t sample_count) {
     Serial.printf("[MIC] WAV: samples=%u bytes=%u sr=%u\n",
                   (unsigned)sample_count, (unsigned)wav_size, (unsigned)MIC_SAMPLE_RATE);
 
-    storeLastRecording(wav, wav_size);
+    const bool stored = storeLastRecording(wav, wav_size, source);
     free(wav);
+    if (!stored) {
+        return false;
+    }
     logAudioMemory("mic-store");
     setFaceExpression(FACE_IDLE);
     return true;

--- a/firmware/src/mic_service.h
+++ b/firmware/src/mic_service.h
@@ -10,10 +10,12 @@ struct MicRuntimeStatus {
     uint32_t frameCount = 0;
     uint32_t recordFailureCount = 0;
     uint32_t triggerCount = 0;
+    uint32_t touchTriggerCount = 0;
     uint32_t storedRecordingCount = 0;
 };
 
 bool initMicrophone();
 void updateMicrophone();
+bool requestTouchRecording();
 const char* getMicStateName();
 MicRuntimeStatus getMicRuntimeStatus();

--- a/firmware/src/mic_service.h
+++ b/firmware/src/mic_service.h
@@ -1,6 +1,19 @@
 #pragma once
 #include <stdint.h>
 
+struct MicRuntimeStatus {
+    bool enabled = false;
+    bool running = false;
+    float lastRms = 0.0f;
+    float recentPeakRms = 0.0f;
+    uint32_t lastFrameMs = 0;
+    uint32_t frameCount = 0;
+    uint32_t recordFailureCount = 0;
+    uint32_t triggerCount = 0;
+    uint32_t storedRecordingCount = 0;
+};
+
 bool initMicrophone();
-void updateMicrophone();  
+void updateMicrophone();
 const char* getMicStateName();
+MicRuntimeStatus getMicRuntimeStatus();

--- a/firmware/src/playback_service.cpp
+++ b/firmware/src/playback_service.cpp
@@ -40,6 +40,7 @@ static uint32_t s_nextAudioSequence = 0;
 #define MAX_QUEUED_PCM_BYTES  (2 * 1024 * 1024)
 #define SPEAKER_PLAYBACK_CHANNEL 0
 #define MAX_AUDIO_QUEUE_DEPTH 16
+#define DOWNLOAD_WATCHDOG_MS 60000
 
 // ── FreeRTOS: URLをCore 0に渡すキュー
 //    StringはFreeRTOSキューに乗せられないのでchar配列で渡す
@@ -62,7 +63,9 @@ struct DownloadedAudio {
 static std::queue<PcmBuffer> s_pcmQueue;
 static size_t s_pcmQueuedBytes = 0;
 static QueueHandle_t s_downloadCompleteQueue = nullptr;
+static TaskHandle_t s_downloadTaskHandle = nullptr;
 static bool s_downloadInFlight = false;
+static unsigned long s_downloadStartedMs = 0;
 static unsigned long s_lastSpeakerEndMs = 0;
 static uint8_t* s_stagedPcmData = nullptr;
 static size_t s_stagedPcmSize = 0;
@@ -72,6 +75,15 @@ static long s_stagedPcmNextSeq = 0;
 
 static void processAudioQueue();
 static void clearStagedPcmPlayback();
+
+static bool publishDownloadResult(const DownloadedAudio& completed) {
+    if (!s_downloadCompleteQueue) {
+        return false;
+    }
+    // A single download is allowed in flight. Preserve its only completion
+    // event so the main loop can always clear s_downloadInFlight.
+    return xQueueSend(s_downloadCompleteQueue, &completed, portMAX_DELAY) == pdTRUE;
+}
 
 static bool hasPendingPlaybackWork() {
     return s_downloadInFlight || !s_audioQueue.empty() || !s_pcmQueue.empty() || isPcmStreamActive();
@@ -204,21 +216,20 @@ static void downloadTask(void* arg) {
         uint8_t* data = nullptr;
         size_t   size = 0;
 
-        if (downloadVoice(String(url), &data, &size)) {
-            DownloadedAudio completed = {data, size, true};
-            if (!s_downloadCompleteQueue ||
-                xQueueSend(s_downloadCompleteQueue, &completed, 0) != pdTRUE) {
-                Serial.println("[DOWNLOAD] Complete queue full; dropping audio");
+        bool success = downloadVoice(String(url), &data, &size);
+        DownloadedAudio completed = {data, size, success};
+        if (!publishDownloadResult(completed)) {
+            Serial.println("[DOWNLOAD] Completion queue unavailable");
+            if (data) {
                 free(data);
-                continue;
             }
+            continue;
+        }
+
+        if (success) {
             Serial.printf("[DOWNLOAD] Ready: %u bytes\n", (unsigned)size);
         } else {
             Serial.println("[DOWNLOAD] Failed");
-            DownloadedAudio completed = {nullptr, 0, false};
-            if (s_downloadCompleteQueue) {
-                xQueueSend(s_downloadCompleteQueue, &completed, 0);
-            }
         }
     }
 }
@@ -228,20 +239,37 @@ static void downloadTask(void* arg) {
 // ════════════════════════════════════════
 void initPlayback() {
     s_downloadQueue = xQueueCreate(4, sizeof(char) * MAX_URL_LEN);
-    s_downloadCompleteQueue = xQueueCreate(2, sizeof(DownloadedAudio));
+    s_downloadCompleteQueue = xQueueCreate(1, sizeof(DownloadedAudio));
     if (!s_downloadQueue || !s_downloadCompleteQueue) {
         Serial.println("[PLAY] Failed to create playback queues");
+        if (s_downloadQueue) {
+            vQueueDelete(s_downloadQueue);
+            s_downloadQueue = nullptr;
+        }
+        if (s_downloadCompleteQueue) {
+            vQueueDelete(s_downloadCompleteQueue);
+            s_downloadCompleteQueue = nullptr;
+        }
         return;
     }
-    xTaskCreatePinnedToCore(
+    BaseType_t created = xTaskCreatePinnedToCore(
         downloadTask,
         "downloadTask",
         8192,
         nullptr,
         1,
-        nullptr,
+        &s_downloadTaskHandle,
         1   // Core 1
     );
+    if (created != pdPASS) {
+        Serial.println("[PLAY] Failed to create download task");
+        vQueueDelete(s_downloadQueue);
+        vQueueDelete(s_downloadCompleteQueue);
+        s_downloadQueue = nullptr;
+        s_downloadCompleteQueue = nullptr;
+        s_downloadTaskHandle = nullptr;
+        return;
+    }
     Serial.println("[PLAY] Download task started on Core 1");
     logAudioMemory("play-init");
 }
@@ -251,8 +279,8 @@ void initPlayback() {
 //  enqueueAudioTask()から呼ばれる
 // ════════════════════════════════════════
 static bool startPlayback(const AudioTask& task) {
-    if (!s_downloadQueue) {
-        Serial.println("[PLAY] Queue not initialized!");
+    if (!s_downloadQueue || !s_downloadCompleteQueue || !s_downloadTaskHandle) {
+        Serial.println("[PLAY] Download pipeline not initialized");
         return false;
     }
     if (s_downloadInFlight) {
@@ -266,6 +294,7 @@ static bool startPlayback(const AudioTask& task) {
         return false;
     }
     s_downloadInFlight = true;
+    s_downloadStartedMs = millis();
     setFaceExpression(FACE_THINKING);
     Serial.printf("[PLAY] Queued for download: %s\n", url);
     return true;
@@ -355,6 +384,7 @@ static void checkPendingPlayback() {
         return;
     }
     s_downloadInFlight = false;
+    s_downloadStartedMs = 0;
     if (!completed.success || !startDownloadedWavPlayback(completed.data, completed.size)) {
         setFaceExpression(FACE_IDLE);
         processAudioQueue();
@@ -578,6 +608,8 @@ PlaybackStatus getPlaybackStatus() {
     status.audioQueueDepth = s_audioQueue.size();
     status.downloadQueueDepth = s_downloadQueue ? uxQueueMessagesWaiting(s_downloadQueue) : 0;
     status.downloadInFlight = s_downloadInFlight;
+    status.downloadAgeMs = s_downloadInFlight ? millis() - s_downloadStartedMs : 0;
+    status.downloadWatchdogMs = DOWNLOAD_WATCHDOG_MS;
     status.micResumeRequested = s_micResumeRequested;
     status.startedMs = s_playbackStartMs;
     status.deadlineMs = s_playbackDeadlineMs;
@@ -676,6 +708,15 @@ static bool notifyPlaybackFinished() {
 
 void updatePlayback() {
     checkPendingPlayback();
+
+    if (s_downloadInFlight && millis() - s_downloadStartedMs > DOWNLOAD_WATCHDOG_MS) {
+        Serial.printf("[DOWNLOAD] Watchdog expired after %u ms; restarting device\n",
+                      (unsigned)(millis() - s_downloadStartedMs));
+        Serial.flush();
+        delay(100);
+        ESP.restart();
+    }
+
     updateLipSync();
 
     if (s_isPlaying &&

--- a/firmware/src/playback_service.h
+++ b/firmware/src/playback_service.h
@@ -27,6 +27,8 @@ struct PlaybackStatus {
     size_t audioQueueDepth = 0;
     size_t downloadQueueDepth = 0;
     bool downloadInFlight = false;
+    unsigned long downloadAgeMs = 0;
+    unsigned long downloadWatchdogMs = 0;
     bool micResumeRequested = false;
     unsigned long startedMs = 0;
     unsigned long deadlineMs = 0;

--- a/firmware/src/recording_store.cpp
+++ b/firmware/src/recording_store.cpp
@@ -4,6 +4,7 @@
 static uint8_t* s_wavBuf = nullptr;
 static size_t s_wavSize = 0;
 static bool s_wavReady = false;
+static RecordingSource s_recordingSource = RecordingSource::NONE;
 
 void clearLastRecording() {
     if (s_wavBuf) {
@@ -12,9 +13,10 @@ void clearLastRecording() {
     s_wavBuf = nullptr;
     s_wavSize = 0;
     s_wavReady = false;
+    s_recordingSource = RecordingSource::NONE;
 }
 
-bool storeLastRecording(const uint8_t* wav, size_t size) {
+bool storeLastRecording(const uint8_t* wav, size_t size, RecordingSource source) {
     clearLastRecording();
 
     s_wavBuf = (uint8_t*)ps_malloc(size);
@@ -25,7 +27,9 @@ bool storeLastRecording(const uint8_t* wav, size_t size) {
     memcpy(s_wavBuf, wav, size);
     s_wavSize = size;
     s_wavReady = true;
-    Serial.printf("[REC] Stored recording: %u bytes\n", (unsigned)size);
+    s_recordingSource = source;
+    Serial.printf("[REC] Stored recording: %u bytes source=%s\n",
+                  (unsigned)size, recordingSourceName(source));
     return true;
 }
 
@@ -42,6 +46,19 @@ RecordingSnapshot getLastRecording() {
     return snapshot;
 }
 
+RecordingSource getLastRecordingSource() {
+    return hasLastRecording() ? s_recordingSource : RecordingSource::NONE;
+}
+
+const char* recordingSourceName(RecordingSource source) {
+    switch (source) {
+        case RecordingSource::VOICE: return "voice";
+        case RecordingSource::TOUCH: return "touch";
+        default: return "none";
+    }
+}
+
 void markLastRecordingConsumed() {
     s_wavReady = false;
+    s_recordingSource = RecordingSource::NONE;
 }

--- a/firmware/src/recording_store.h
+++ b/firmware/src/recording_store.h
@@ -3,13 +3,21 @@
 #include <stddef.h>
 #include <stdint.h>
 
+enum class RecordingSource : uint8_t {
+    NONE,
+    VOICE,
+    TOUCH,
+};
+
 struct RecordingSnapshot {
     const uint8_t* data = nullptr;
     size_t size = 0;
 };
 
 void clearLastRecording();
-bool storeLastRecording(const uint8_t* wav, size_t size);
+bool storeLastRecording(const uint8_t* wav, size_t size, RecordingSource source);
 bool hasLastRecording();
 RecordingSnapshot getLastRecording();
+RecordingSource getLastRecordingSource();
+const char* recordingSourceName(RecordingSource source);
 void markLastRecordingConsumed();

--- a/firmware/src/touch_gesture.h
+++ b/firmware/src/touch_gesture.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <stdint.h>
+
+enum class TouchSwipeDirection : uint8_t {
+    FORWARD,
+    BACKWARD,
+};
+
+struct TouchTrajectoryResult {
+    bool hasSwipe = false;
+    TouchSwipeDirection direction = TouchSwipeDirection::FORWARD;
+    bool suppressClick = false;
+};
+
+class TouchTrajectoryDetector {
+public:
+    TouchTrajectoryResult update(const uint8_t intensities[3]) {
+        TouchTrajectoryResult result;
+        const bool anyTouched = intensities[0] > 0 || intensities[1] > 0 || intensities[2] > 0;
+        if (!anyTouched) {
+            result.suppressClick = contactActive_ && strokeObserved_;
+            reset();
+            return result;
+        }
+
+        if (!contactActive_) {
+            contactActive_ = true;
+            lastZone_ = Zone::NONE;
+            strokeObserved_ = false;
+        }
+
+        result.suppressClick = strokeObserved_;
+        const Zone zone = classifyZone(intensities);
+        if (zone == Zone::NONE) {
+            return result;
+        }
+        if (lastZone_ == Zone::NONE) {
+            lastZone_ = zone;
+            return result;
+        }
+        if (zone == lastZone_ || !shouldTransition(lastZone_, zone, intensities)) {
+            return result;
+        }
+
+        result.hasSwipe = true;
+        result.direction = zoneIndex(zone) > zoneIndex(lastZone_) ? TouchSwipeDirection::FORWARD
+                                                                 : TouchSwipeDirection::BACKWARD;
+        result.suppressClick = true;
+        strokeObserved_ = true;
+        lastZone_ = zone;
+        return result;
+    }
+
+    void reset() {
+        contactActive_ = false;
+        strokeObserved_ = false;
+        lastZone_ = Zone::NONE;
+    }
+
+private:
+    enum class Zone : uint8_t {
+        NONE,
+        FRONT,
+        MIDDLE,
+        BACK,
+    };
+
+    static Zone classifyZone(const uint8_t intensities[3]) {
+        int8_t bestIndex = -1;
+        uint8_t bestIntensity = 0;
+        for (int8_t index = 0; index < 3; ++index) {
+            if (intensities[index] > 0 && intensities[index] >= bestIntensity) {
+                bestIndex = index;
+                bestIntensity = intensities[index];
+            }
+        }
+        return bestIndex < 0 ? Zone::NONE : static_cast<Zone>(bestIndex + 1);
+    }
+
+    static int8_t zoneIndex(Zone zone) {
+        return static_cast<int8_t>(zone) - 1;
+    }
+
+    static bool shouldTransition(Zone current, Zone candidate, const uint8_t intensities[3]) {
+        constexpr uint8_t MIN_FORWARD_INTENSITY = 2;
+        constexpr uint8_t REVERSE_HYSTERESIS = 2;
+
+        const uint8_t candidateIntensity = intensities[zoneIndex(candidate)];
+        if (zoneIndex(candidate) > zoneIndex(current)) {
+            return candidateIntensity >= MIN_FORWARD_INTENSITY;
+        }
+
+        const uint8_t currentIntensity = intensities[zoneIndex(current)];
+        return candidateIntensity >= currentIntensity + REVERSE_HYSTERESIS;
+    }
+
+    bool contactActive_ = false;
+    bool strokeObserved_ = false;
+    Zone lastZone_ = Zone::NONE;
+};
+
+class PettingDetector {
+public:
+    explicit PettingDetector(uint32_t windowMs = 1500) : windowMs_(windowMs) {}
+
+    bool observe(TouchSwipeDirection direction, uint32_t nowMs) {
+        if (direction == TouchSwipeDirection::FORWARD) {
+            if (hasBackward_ && nowMs - backwardMs_ <= windowMs_) {
+                reset();
+                return true;
+            }
+            forwardMs_ = nowMs;
+            hasForward_ = true;
+            return false;
+        }
+
+        if (hasForward_ && nowMs - forwardMs_ <= windowMs_) {
+            reset();
+            return true;
+        }
+        backwardMs_ = nowMs;
+        hasBackward_ = true;
+        return false;
+    }
+
+    void reset() {
+        hasForward_ = false;
+        hasBackward_ = false;
+        forwardMs_ = 0;
+        backwardMs_ = 0;
+    }
+
+private:
+    uint32_t windowMs_;
+    bool hasForward_ = false;
+    bool hasBackward_ = false;
+    uint32_t forwardMs_ = 0;
+    uint32_t backwardMs_ = 0;
+};

--- a/firmware/src/touch_service.cpp
+++ b/firmware/src/touch_service.cpp
@@ -1,0 +1,197 @@
+#include "touch_service.h"
+
+#include <Arduino.h>
+#include <M5StackChan.h>
+#include <M5Unified.h>
+#include <string.h>
+
+#include "face_service.h"
+#include "mic_service.h"
+#include "pcm_stream_service.h"
+#include "playback_service.h"
+#include "servo_service.h"
+#include "touch_gesture.h"
+
+namespace {
+
+constexpr uint8_t TOUCH_SENSOR_ADDRESS = 0x68;
+constexpr uint32_t CLICK_AFTER_SWIPE_GUARD_MS = 500;
+constexpr uint32_t PETTING_DURATION_MS = 5000;
+constexpr uint32_t RESUME_RETRY_INTERVAL_MS = 2000;
+
+TouchRuntimeStatus status;
+TouchTrajectoryDetector trajectoryDetector;
+PettingDetector pettingDetector;
+bool touchSensorExpected = false;
+bool resumeRetryPending = false;
+bool pettingOwnsFace = false;
+uint32_t pettingStartedMs = 0;
+uint32_t pettingFaceRevision = 0;
+uint32_t lastResumeAttemptMs = 0;
+uint32_t lastSwipeMs = 0;
+WhaleFace faceBeforePetting = WHALE_CALM;
+
+void clearIntensities() {
+    for (uint8_t& intensity : status.intensities) {
+        intensity = 0;
+    }
+}
+
+void recordEvent(const char* event, uint32_t nowMs) {
+    status.lastEvent = event;
+    status.lastEventMs = nowMs;
+}
+
+bool audioIsBusy() {
+    return isPlaybackActive() || isPcmStreamActive() || strcmp(getMicStateName(), "idle") != 0;
+}
+
+void startPetting(uint32_t nowMs) {
+    ++status.petCount;
+    if (audioIsBusy()) {
+        ++status.suppressedPetCount;
+        Serial.println("[TOUCH] Petting detected; animation suppressed while audio is busy");
+        return;
+    }
+
+    const bool stillOwnsCurrentFace =
+        status.pettingActive && pettingOwnsFace && getFaceCommandRevision() == pettingFaceRevision;
+    if (!stillOwnsCurrentFace) {
+        WhaleFace current = WHALE_CALM;
+        if (whaleFaceFromName(getCurrentFaceName(), &current)) {
+            faceBeforePetting = current;
+        }
+    }
+
+    // The compiled WHALE_HAPPY asset is koke_cheering.gif.
+    setWhaleFace(WHALE_HAPPY);
+    pettingFaceRevision = getFaceCommandRevision();
+    pettingOwnsFace = true;
+    pettingStartedMs = nowMs;
+    status.pettingActive = true;
+
+    if (isServoReady()) {
+        servoShake();
+    }
+    Serial.println("[TOUCH] Petting gesture detected");
+}
+
+void finishPettingIfDue(uint32_t nowMs) {
+    if (!status.pettingActive || nowMs - pettingStartedMs < PETTING_DURATION_MS) {
+        return;
+    }
+
+    status.pettingActive = false;
+    if (pettingOwnsFace && getFaceCommandRevision() == pettingFaceRevision) {
+        setWhaleFace(faceBeforePetting);
+    }
+    pettingOwnsFace = false;
+}
+
+void handleSwipe(TouchSwipeDirection direction, uint32_t nowMs) {
+    lastSwipeMs = nowMs;
+    if (pettingDetector.observe(direction, nowMs)) {
+        recordEvent("petting", nowMs);
+        startPetting(nowMs);
+        return;
+    }
+
+    recordEvent(direction == TouchSwipeDirection::FORWARD ? "swipe_forward" : "swipe_backward", nowMs);
+}
+
+}  // namespace
+
+bool initTouchService() {
+    status.suspended = false;
+    status.available = M5.In_I2C.scanID(TOUCH_SENSOR_ADDRESS);
+    touchSensorExpected = status.available;
+    resumeRetryPending = false;
+    clearIntensities();
+    trajectoryDetector.reset();
+    pettingDetector.reset();
+    lastResumeAttemptMs = 0;
+    lastSwipeMs = 0;
+    Serial.printf("[TOUCH] Si12T %s at 0x%02x\n", status.available ? "ready" : "not found", TOUCH_SENSOR_ADDRESS);
+    return status.available;
+}
+
+void updateTouchService() {
+    const uint32_t nowMs = millis();
+    finishPettingIfDue(nowMs);
+
+    if (status.suspended) {
+        return;
+    }
+    if (!status.available) {
+        if (resumeRetryPending && nowMs - lastResumeAttemptMs >= RESUME_RETRY_INTERVAL_MS) {
+            resumeTouchService();
+        }
+        return;
+    }
+
+    const auto& intensities = M5StackChan.TouchSensor.getIntensities();
+    for (size_t i = 0; i < 3; ++i) {
+        status.intensities[i] = intensities[i];
+    }
+
+    const TouchTrajectoryResult trajectory = trajectoryDetector.update(status.intensities);
+    if (trajectory.hasSwipe) {
+        handleSwipe(trajectory.direction, nowMs);
+        return;
+    }
+    if (M5StackChan.TouchSensor.wasHold()) {
+        recordEvent("hold", nowMs);
+        return;
+    }
+    if (M5StackChan.TouchSensor.wasClicked() && !trajectory.suppressClick &&
+        nowMs - lastSwipeMs > CLICK_AFTER_SWIPE_GUARD_MS) {
+        ++status.recordRequestCount;
+        if (requestTouchRecording()) {
+            recordEvent("recording_started", nowMs);
+        } else {
+            ++status.recordStartFailureCount;
+            recordEvent("recording_rejected", nowMs);
+        }
+    }
+}
+
+void suspendTouchService() {
+    status.suspended = true;
+    clearIntensities();
+    trajectoryDetector.reset();
+    pettingDetector.reset();
+}
+
+bool resumeTouchService() {
+    lastResumeAttemptMs = millis();
+    const bool busReady = M5.In_I2C.begin();
+    const bool sensorPresent = busReady && M5.In_I2C.scanID(TOUCH_SENSOR_ADDRESS);
+    if (sensorPresent) {
+        M5StackChan.TouchSensor.begin();
+    }
+
+    status.available = sensorPresent;
+    status.suspended = false;
+    clearIntensities();
+    trajectoryDetector.reset();
+    pettingDetector.reset();
+    lastSwipeMs = 0;
+
+    const bool restored = busReady && (!touchSensorExpected || sensorPresent);
+    resumeRetryPending = !restored;
+    if (!restored) {
+        ++status.resumeFailureCount;
+        Serial.printf("[TOUCH] Resume failed: bus=%s sensor=%s expected=%s\n",
+                      busReady ? "ready" : "failed", sensorPresent ? "ready" : "missing",
+                      touchSensorExpected ? "yes" : "no");
+        return false;
+    }
+
+    Serial.printf("[TOUCH] Internal I2C resumed (sensor=%s)\n",
+                  sensorPresent ? "ready" : "not present");
+    return true;
+}
+
+TouchRuntimeStatus getTouchRuntimeStatus() {
+    return status;
+}

--- a/firmware/src/touch_service.h
+++ b/firmware/src/touch_service.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stdint.h>
+
+struct TouchRuntimeStatus {
+    bool available = false;
+    bool suspended = false;
+    bool pettingActive = false;
+    uint8_t intensities[3] = {0, 0, 0};
+    const char* lastEvent = "none";
+    uint32_t lastEventMs = 0;
+    uint32_t petCount = 0;
+    uint32_t suppressedPetCount = 0;
+    uint32_t recordRequestCount = 0;
+    uint32_t recordStartFailureCount = 0;
+    uint32_t resumeFailureCount = 0;
+};
+
+// M5StackChan.begin() initializes the driver. This probe records whether the
+// Si12T is actually reachable on the shared internal I2C bus.
+bool initTouchService();
+
+// Consume one-shot touch events after M5StackChan.update().
+void updateTouchService();
+
+// The CoreS3 camera shares GPIO 11/12 with the internal I2C bus. Snapshot code
+// must suspend touch before taking the bus and resume it on every exit path.
+void suspendTouchService();
+bool resumeTouchService();
+
+TouchRuntimeStatus getTouchRuntimeStatus();

--- a/firmware/src/wifi_manager.cpp
+++ b/firmware/src/wifi_manager.cpp
@@ -1,53 +1,99 @@
 // wifi_manager.cpp
+//
+// 连接优先级：
+//   1. NVS 里用户配网存的凭证（Preferences, namespace "wifi"）
+//   2. config.h 里的 WIFI_SSID_0 / WIFI_SSID_1（硬编码备用）
+//
+// 每个网络超时 15 秒。
+// 全部失败返回 false，main.cpp 负责调用 runWifiPortal()。
 
 #include <M5Unified.h>
 #include <WiFi.h>
+#include <Preferences.h>
 #include "wifi_manager.h"
 #include "config_loader.h"
 
-// ネットワーク定義（config.h の定数を配列にまとめる）
-struct NetworkConfig {
-    const char* ssid;
-    const char* password;
-};
+#define WIFI_CONNECT_TIMEOUT_MS  15000   // 每个网络的超时（ms）
+#define WIFI_RECONNECT_INTERVAL_MS 5000  // serviceWiFi() 重连间隔
 
-static const NetworkConfig NETWORKS[WIFI_NETWORK_COUNT] = {
-    { WIFI_SSID_0, WIFI_PASSWORD_0 },
-    { WIFI_SSID_1, WIFI_PASSWORD_1 },
-};
+// 内部：尝试连接一个 SSID，超时 WIFI_CONNECT_TIMEOUT_MS。
+// 返回 true = 连上。
+static bool tryConnect(const char* ssid, const char* password) {
+    if (!ssid || strlen(ssid) == 0) return false;
 
-#define WIFI_RECONNECT_INTERVAL_MS 5000
+    Serial.printf("[WIFI] Trying: %s\n", ssid);
+    WiFi.begin(ssid, (password && strlen(password) > 0) ? password : nullptr);
 
-void connectWiFi() {
-    Serial.println("\nConnecting to WiFi...");
+    unsigned long start = millis();
+    while (WiFi.status() != WL_CONNECTED) {
+        if (millis() - start >= WIFI_CONNECT_TIMEOUT_MS) {
+            WiFi.disconnect(false);
+            Serial.printf("[WIFI] Timeout: %s\n", ssid);
+            return false;
+        }
+        delay(250);
+        Serial.print(".");
+    }
+    Serial.printf("\n[WIFI] Connected: %s  IP: %s\n",
+                  ssid, WiFi.localIP().toString().c_str());
+    // 连网成功toast：屏幕短暂显示SSID+IP（约3秒），随后被脸覆盖。
+    // 出门/回国场景下让人一眼确认它上的是哪个网。
+    M5.Display.fillScreen(TFT_BLACK);
+    M5.Display.setTextColor(0x07E0);  // 绿色
+    M5.Display.setTextSize(2);
+    M5.Display.setCursor(10, 90);
+    M5.Display.printf("WiFi OK!\n\n  %s\n\n  %s", ssid, WiFi.localIP().toString().c_str());
+    delay(3000);
+    return true;
+}
+
+bool connectWiFi() {
+    Serial.println("\n[WIFI] Starting connection sequence");
     WiFi.mode(WIFI_STA);
 
-    for (int i = 0; i < WIFI_NETWORK_COUNT; i++) {
-        Serial.printf("[WIFI] 試行 %d/%d: %s\n", i + 1, WIFI_NETWORK_COUNT, NETWORKS[i].ssid);
+    // ── 1. NVS 保存的用户凭证（优先）────────────────────────────────────────
+    {
+        Preferences prefs;
+        prefs.begin("wifi", true);   // read-only
+        String nvsSsid = prefs.getString("ssid", "");
+        String nvsPass = prefs.getString("pass", "");
+        prefs.end();
 
-        WiFi.begin(NETWORKS[i].ssid, NETWORKS[i].password);
-
-        int attempts = 0;
-        while (WiFi.status() != WL_CONNECTED && attempts < 20) {
-            delay(500);
-            Serial.print(".");
-            attempts++;
+        if (nvsSsid.length() > 0) {
+            Serial.printf("[WIFI] NVS credentials found: %s\n", nvsSsid.c_str());
+            if (tryConnect(nvsSsid.c_str(), nvsPass.c_str())) {
+                return true;
+            }
+            Serial.println("[WIFI] NVS credentials failed, trying hardcoded networks");
+        } else {
+            Serial.println("[WIFI] No NVS credentials");
         }
-
-        if (WiFi.status() == WL_CONNECTED) {
-            Serial.printf("\n[WIFI] 接続成功: %s\n", NETWORKS[i].ssid);
-            Serial.printf("[WIFI] IP: %s\n", WiFi.localIP().toString().c_str());
-
-            return;
-        }
-
-        // このネットワークに繋がらなかった → 次を試す
-        WiFi.disconnect();
-        Serial.printf("\n[WIFI] %s に接続できませんでした\n", NETWORKS[i].ssid);
     }
 
-    // 全部失敗
-    Serial.println("[WIFI] ❌ すべてのネットワークへの接続に失敗しました");
+    // ── 2. config.h の硬编码网络（依次尝试）────────────────────────────────
+
+    struct NetEntry { const char* ssid; const char* pass; };
+    static const NetEntry NETWORKS[WIFI_NETWORK_COUNT] = {
+#if WIFI_NETWORK_COUNT >= 1
+        { WIFI_SSID_0, WIFI_PASSWORD_0 },
+#endif
+#if WIFI_NETWORK_COUNT >= 2
+        { WIFI_SSID_1, WIFI_PASSWORD_1 },
+#endif
+#if WIFI_NETWORK_COUNT >= 3
+        { WIFI_SSID_2, WIFI_PASSWORD_2 },
+#endif
+    };
+
+    for (int i = 0; i < WIFI_NETWORK_COUNT; i++) {
+        if (tryConnect(NETWORKS[i].ssid, NETWORKS[i].pass)) {
+            return true;
+        }
+    }
+
+    // ── 全部失败 ──────────────────────────────────────────────────────────────
+    Serial.println("[WIFI] All networks failed");
+    return false;
 }
 
 void serviceWiFi() {

--- a/firmware/src/wifi_manager.h
+++ b/firmware/src/wifi_manager.h
@@ -1,7 +1,12 @@
 #ifndef WIFI_MANAGER_H
 #define WIFI_MANAGER_H
 
-void connectWiFi();
+// WiFi 连接尝试。
+// 返回 true  = 连上了某个网络。
+// 返回 false = 全部失败，调用方应进入配网模式。
+bool connectWiFi();
+
+// 在 loop() 里调用：断线后自动重连。
 void serviceWiFi();
 
 #endif

--- a/firmware/src/wifi_portal.cpp
+++ b/firmware/src/wifi_portal.cpp
@@ -43,7 +43,7 @@ static void drawPortalScreen() {
     M5.Display.setTextColor(0x07FF);
     M5.Display.setCursor(10, 78);
     M5.Display.print("Open:  ");
-    M5.Display.println("192.168.4.1");
+    M5.Display.println(WiFi.softAPIP().toString());
 
     // Steps (large enough for phone camera)
     M5.Display.setTextSize(2);
@@ -204,7 +204,7 @@ void runWifiPortal() {
 
     // Captive-portal redirect: phones probe random URLs to detect a portal
     portalServer.onNotFound([&]() {
-        portalServer.sendHeader("Location", "http://192.168.4.1/", true);
+        portalServer.sendHeader("Location", String("http://") + WiFi.softAPIP().toString() + "/", true);
         portalServer.send(302, "text/plain", "");
     });
 

--- a/firmware/src/wifi_portal.cpp
+++ b/firmware/src/wifi_portal.cpp
@@ -1,0 +1,238 @@
+// wifi_portal.cpp
+// WiFi captive portal for Stack-chan CoreS3
+//
+// Runs when all known WiFi networks fail, or when BtnA is held at boot.
+// Does NOT start face / camera / servo / env / http_server services.
+// Blocks until the user saves new credentials, then calls ESP.restart().
+
+#include "wifi_portal.h"
+
+#include <M5Unified.h>
+#include <WiFi.h>
+#include <WebServer.h>
+#include <Preferences.h>
+
+static const char* PORTAL_AP_SSID     = "StackChan-Setup";
+static const char* PORTAL_AP_PASSWORD = "";   // empty = open network
+static const IPAddress PORTAL_IP(192, 168, 4, 1);
+
+// ---------------------------------------------------------------------------
+// Screen display
+// ---------------------------------------------------------------------------
+
+static void drawPortalScreen() {
+    M5.Display.fillScreen(0x000F);            // dark-blue background
+
+    // Title
+    M5.Display.setTextColor(0xFFFF);
+    M5.Display.setTextSize(2);
+    M5.Display.setCursor(10, 10);
+    M5.Display.println("WiFi Setup");
+
+    // Divider
+    M5.Display.drawLine(0, 38, M5.Display.width(), 38, 0x7BEF);
+
+    // AP name (yellow)
+    M5.Display.setTextSize(2);
+    M5.Display.setTextColor(0xFFE0);
+    M5.Display.setCursor(10, 48);
+    M5.Display.print("Wi-Fi: ");
+    M5.Display.println(PORTAL_AP_SSID);
+
+    // URL (cyan)
+    M5.Display.setTextColor(0x07FF);
+    M5.Display.setCursor(10, 78);
+    M5.Display.print("Open:  ");
+    M5.Display.println("192.168.4.1");
+
+    // Steps (large enough for phone camera)
+    M5.Display.setTextSize(2);
+    M5.Display.setTextColor(0xFFFF);
+    M5.Display.setCursor(10, 118);
+    M5.Display.println("1. Join above Wi-Fi");
+    M5.Display.setCursor(10, 142);
+    M5.Display.println("2. Open browser");
+    M5.Display.setCursor(10, 166);
+    M5.Display.println("3. Pick SSID & Save");
+
+    // Footer note
+    M5.Display.setTextSize(1);
+    M5.Display.setTextColor(0x8410);
+    M5.Display.setCursor(10, 210);
+    M5.Display.println("Hold BtnA at boot to force portal");
+}
+
+// ---------------------------------------------------------------------------
+// HTML pages  (all ASCII — browser renders fine; device-side chars are ASCII)
+// ---------------------------------------------------------------------------
+
+static String escapeHtml(const String& value) {
+    String escaped;
+    escaped.reserve(value.length() + 16);
+    for (size_t i = 0; i < value.length(); ++i) {
+        switch (value[i]) {
+            case '&':
+                escaped += "&amp;";
+                break;
+            case '<':
+                escaped += "&lt;";
+                break;
+            case '>':
+                escaped += "&gt;";
+                break;
+            case '"':
+                escaped += "&quot;";
+                break;
+            case '\'':
+                escaped += "&#39;";
+                break;
+            default:
+                escaped += value[i];
+                break;
+        }
+    }
+    return escaped;
+}
+
+// Build the Wi-Fi selection form dynamically with scanned SSIDs.
+static String buildIndexPage(int networkCount, const String ssidList[]) {
+    String html;
+    html += "<!DOCTYPE html>\n";
+    html += "<html lang=\"zh\">\n";
+    html += "<head>\n";
+    html += "<meta charset=\"utf-8\">\n";
+    html += "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\n";
+    html += "<title>StackChan WiFi Setup</title>\n";
+    html += "<style>\n";
+    html += "body{font-family:sans-serif;max-width:400px;margin:40px auto;padding:0 16px;background:#f0f4ff}\n";
+    html += "h1{color:#334;font-size:1.4em}\n";
+    html += "label{display:block;margin-top:16px;font-weight:bold;color:#445}\n";
+    html += "select,input{width:100%;padding:10px;font-size:1em;border:1px solid #aac;border-radius:6px;box-sizing:border-box;margin-top:4px}\n";
+    html += "button{margin-top:20px;width:100%;padding:12px;background:#3366cc;color:#fff;border:none;border-radius:6px;font-size:1em;cursor:pointer}\n";
+    html += "button:active{background:#2244aa}\n";
+    html += ".note{color:#888;font-size:0.85em;margin-top:8px}\n";
+    html += "</style>\n";
+    html += "</head>\n";
+    html += "<body>\n";
+    html += "<h1>StackChan WiFi Setup</h1>\n";
+    html += "<form method=\"POST\" action=\"/save\">\n";
+    html += "  <label>Select Network</label>\n";
+    html += "  <select name=\"ssid\">\n";
+
+    for (int i = 0; i < networkCount; i++) {
+        const String escapedSsid = escapeHtml(ssidList[i]);
+        html += "    <option value=\"" + escapedSsid + "\">" + escapedSsid + "</option>\n";
+    }
+
+    html += "  </select>\n";
+    html += "  <label>Password</label>\n";
+    html += "  <input type=\"password\" name=\"pass\" placeholder=\"(leave blank if none)\">\n";
+    html += "  <p class=\"note\">Device will restart and connect to the selected network.</p>\n";
+    html += "  <button type=\"submit\">Save &amp; Restart</button>\n";
+    html += "</form>\n";
+    html += "</body>\n";
+    html += "</html>\n";
+    return html;
+}
+
+static const char SAVE_OK_PAGE[] =
+    "<!DOCTYPE html>"
+    "<html lang=\"zh\">"
+    "<head>"
+    "<meta charset=\"utf-8\">"
+    "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+    "<title>Saved</title>"
+    "<style>"
+    "body{font-family:sans-serif;max-width:400px;margin:60px auto;text-align:center;background:#f0f4ff}"
+    "h1{color:#393}"
+    "p{color:#555}"
+    "</style>"
+    "</head>"
+    "<body>"
+    "<h1>&#10003; Saved</h1>"
+    "<p>Credentials saved. Restarting...</p>"
+    "<p>Wait ~10 seconds for StackChan to reconnect.</p>"
+    "</body>"
+    "</html>";
+
+// ---------------------------------------------------------------------------
+// Main portal entry point
+// ---------------------------------------------------------------------------
+
+void runWifiPortal() {
+    Serial.println("[PORTAL] Starting WiFi captive portal");
+
+    // Switch to AP-only mode
+    WiFi.disconnect(true);
+    delay(100);
+    WiFi.mode(WIFI_AP);
+
+    bool apOk = WiFi.softAP(PORTAL_AP_SSID, PORTAL_AP_PASSWORD);
+    if (!apOk) {
+        Serial.println("[PORTAL] softAP() failed!");
+    }
+    WiFi.softAPConfig(PORTAL_IP, PORTAL_IP, IPAddress(255, 255, 255, 0));
+    delay(200);
+
+    Serial.printf("[PORTAL] AP up: SSID=%s  IP=%s\n",
+                  PORTAL_AP_SSID, WiFi.softAPIP().toString().c_str());
+
+    // Draw screen first, then scan (scan takes a few seconds)
+    drawPortalScreen();
+
+    // Scan for nearby networks
+    int n = WiFi.scanNetworks();
+    String ssids[32];
+    int ssidCount = 0;
+    for (int i = 0; i < n && ssidCount < 32; i++) {
+        String s = WiFi.SSID(i);
+        if (s.length() == 0) continue;
+        bool dup = false;
+        for (int j = 0; j < ssidCount; j++) {
+            if (ssids[j] == s) { dup = true; break; }
+        }
+        if (!dup) ssids[ssidCount++] = s;
+    }
+    Serial.printf("[PORTAL] Scanned %d unique SSIDs\n", ssidCount);
+
+    // Serve the portal
+    WebServer portalServer(80);
+
+    portalServer.on("/", HTTP_GET, [&]() {
+        portalServer.send(200, "text/html", buildIndexPage(ssidCount, ssids));
+    });
+
+    // Captive-portal redirect: phones probe random URLs to detect a portal
+    portalServer.onNotFound([&]() {
+        portalServer.sendHeader("Location", "http://192.168.4.1/", true);
+        portalServer.send(302, "text/plain", "");
+    });
+
+    portalServer.on("/save", HTTP_POST, [&]() {
+        String ssid = portalServer.arg("ssid");
+        String pass = portalServer.arg("pass");
+
+        Serial.printf("[PORTAL] Saving credentials: ssid=%s\n", ssid.c_str());
+
+        Preferences prefs;
+        prefs.begin("wifi", false);
+        prefs.putString("ssid", ssid);
+        prefs.putString("pass", pass);
+        prefs.end();
+
+        portalServer.send(200, "text/html", SAVE_OK_PAGE);
+        delay(2000);
+        ESP.restart();
+    });
+
+    portalServer.begin();
+    Serial.println("[PORTAL] HTTP server started on port 80");
+
+    // Block here — no other tasks running, so no scheduling conflicts
+    while (true) {
+        portalServer.handleClient();
+        M5.update();
+        delay(10);
+    }
+    // Never reached; /save handler calls ESP.restart()
+}

--- a/firmware/src/wifi_portal.h
+++ b/firmware/src/wifi_portal.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// WiFi 配网 Portal（Captive Portal）
+// 全部 WiFi 连接失败时启动，或开机按 BtnA 强制触发。
+// 此模式下不启动 face/camera/servo/env/http 任何服务。
+
+// 进入 portal 并阻塞直到用户完成配网并重启。
+// 函数永远不会返回（内部会 ESP.restart()）。
+void runWifiPortal();

--- a/firmware/test/test_touch_gesture/test_main.cpp
+++ b/firmware/test/test_touch_gesture/test_main.cpp
@@ -1,0 +1,180 @@
+#include <unity.h>
+
+#include <stdint.h>
+
+#include "touch_gesture.h"
+
+TouchTrajectoryResult sample(TouchTrajectoryDetector& detector, uint8_t front, uint8_t middle, uint8_t back) {
+    const uint8_t intensities[3] = {front, middle, back};
+    return detector.update(intensities);
+}
+
+void test_single_zone_tap_remains_a_click() {
+    TouchTrajectoryDetector detector;
+    TEST_ASSERT_FALSE(sample(detector, 1, 0, 0).hasSwipe);
+
+    const TouchTrajectoryResult release = sample(detector, 0, 0, 0);
+    TEST_ASSERT_FALSE(release.hasSwipe);
+    TEST_ASSERT_FALSE(release.suppressClick);
+}
+
+void test_front_to_back_stroke_emits_forward_and_suppresses_release_click() {
+    TouchTrajectoryDetector detector;
+    TEST_ASSERT_FALSE(sample(detector, 2, 0, 0).hasSwipe);
+
+    TouchTrajectoryResult stroke = sample(detector, 0, 2, 0);
+    TEST_ASSERT_TRUE(stroke.hasSwipe);
+    TEST_ASSERT_EQUAL(static_cast<int>(TouchSwipeDirection::FORWARD), static_cast<int>(stroke.direction));
+
+    stroke = sample(detector, 0, 0, 2);
+    TEST_ASSERT_TRUE(stroke.hasSwipe);
+    TEST_ASSERT_EQUAL(static_cast<int>(TouchSwipeDirection::FORWARD), static_cast<int>(stroke.direction));
+    TEST_ASSERT_TRUE(stroke.suppressClick);
+    TEST_ASSERT_TRUE(sample(detector, 0, 0, 0).suppressClick);
+}
+
+void test_back_to_front_stroke_emits_backward() {
+    TouchTrajectoryDetector detector;
+    TEST_ASSERT_FALSE(sample(detector, 0, 0, 2).hasSwipe);
+
+    TouchTrajectoryResult stroke = sample(detector, 0, 2, 0);
+    TEST_ASSERT_TRUE(stroke.hasSwipe);
+    TEST_ASSERT_EQUAL(static_cast<int>(TouchSwipeDirection::BACKWARD), static_cast<int>(stroke.direction));
+
+    stroke = sample(detector, 2, 0, 0);
+    TEST_ASSERT_TRUE(stroke.hasSwipe);
+    TEST_ASSERT_EQUAL(static_cast<int>(TouchSwipeDirection::BACKWARD), static_cast<int>(stroke.direction));
+}
+
+void test_adjacent_zone_round_trip_triggers_petting() {
+    TouchTrajectoryDetector trajectory;
+    PettingDetector petting;
+    TEST_ASSERT_FALSE(sample(trajectory, 3, 0, 0).hasSwipe);
+
+    TouchTrajectoryResult stroke = sample(trajectory, 3, 3, 0);
+    TEST_ASSERT_TRUE(stroke.hasSwipe);
+    TEST_ASSERT_EQUAL(static_cast<int>(TouchSwipeDirection::FORWARD), static_cast<int>(stroke.direction));
+    TEST_ASSERT_FALSE(petting.observe(stroke.direction, 1000));
+
+    stroke = sample(trajectory, 3, 0, 0);
+    TEST_ASSERT_TRUE(stroke.hasSwipe);
+    TEST_ASSERT_EQUAL(static_cast<int>(TouchSwipeDirection::BACKWARD), static_cast<int>(stroke.direction));
+    TEST_ASSERT_TRUE(petting.observe(stroke.direction, 1100));
+}
+
+void test_minor_adjacent_zone_crosstalk_does_not_become_a_swipe() {
+    TouchTrajectoryDetector detector;
+    TEST_ASSERT_FALSE(sample(detector, 3, 0, 0).hasSwipe);
+    TEST_ASSERT_FALSE(sample(detector, 3, 1, 0).hasSwipe);
+    TEST_ASSERT_FALSE(sample(detector, 3, 0, 0).hasSwipe);
+    TEST_ASSERT_FALSE(sample(detector, 0, 0, 0).suppressClick);
+}
+
+void test_reverse_hysteresis_ignores_one_level_wobble() {
+    TouchTrajectoryDetector detector;
+    TEST_ASSERT_FALSE(sample(detector, 3, 3, 0).hasSwipe);
+    TEST_ASSERT_FALSE(sample(detector, 3, 2, 0).hasSwipe);
+    TEST_ASSERT_FALSE(sample(detector, 3, 3, 0).hasSwipe);
+    TEST_ASSERT_FALSE(sample(detector, 0, 0, 0).suppressClick);
+}
+
+void test_continuous_reversal_triggers_petting_without_lifting() {
+    TouchTrajectoryDetector trajectory;
+    PettingDetector petting;
+    TEST_ASSERT_FALSE(sample(trajectory, 2, 0, 0).hasSwipe);
+
+    TouchTrajectoryResult stroke = sample(trajectory, 0, 0, 2);
+    TEST_ASSERT_TRUE(stroke.hasSwipe);
+    TEST_ASSERT_FALSE(petting.observe(stroke.direction, 1000));
+
+    stroke = sample(trajectory, 2, 0, 0);
+    TEST_ASSERT_TRUE(stroke.hasSwipe);
+    TEST_ASSERT_TRUE(petting.observe(stroke.direction, 1200));
+    TEST_ASSERT_TRUE(sample(trajectory, 0, 0, 0).suppressClick);
+}
+
+void test_one_way_adjacent_stroke_suppresses_release_click() {
+    TouchTrajectoryDetector detector;
+    TEST_ASSERT_FALSE(sample(detector, 2, 0, 0).hasSwipe);
+    TEST_ASSERT_TRUE(sample(detector, 0, 2, 0).hasSwipe);
+    TEST_ASSERT_TRUE(sample(detector, 0, 0, 0).suppressClick);
+}
+
+void test_equal_edge_contact_does_not_invent_a_direction() {
+    TouchTrajectoryDetector detector;
+    TEST_ASSERT_FALSE(sample(detector, 2, 1, 2).hasSwipe);
+    TEST_ASSERT_FALSE(sample(detector, 0, 0, 0).suppressClick);
+}
+
+void test_reset_clears_pending_click_suppression() {
+    TouchTrajectoryDetector detector;
+    sample(detector, 2, 0, 0);
+    TEST_ASSERT_TRUE(sample(detector, 0, 0, 2).suppressClick);
+    detector.reset();
+    TEST_ASSERT_FALSE(sample(detector, 0, 0, 0).suppressClick);
+}
+
+void test_one_direction_does_not_trigger_petting() {
+    PettingDetector detector;
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::FORWARD, 1000));
+}
+
+void test_opposite_swipes_inside_window_trigger_petting() {
+    PettingDetector detector;
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::FORWARD, 1000));
+    TEST_ASSERT_TRUE(detector.observe(TouchSwipeDirection::BACKWARD, 2200));
+}
+
+void test_same_direction_does_not_trigger_petting() {
+    PettingDetector detector;
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::FORWARD, 1000));
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::FORWARD, 1200));
+}
+
+void test_latest_same_direction_swipe_starts_a_new_pair_window() {
+    PettingDetector detector;
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::FORWARD, 1000));
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::FORWARD, 2000));
+    TEST_ASSERT_TRUE(detector.observe(TouchSwipeDirection::BACKWARD, 3400));
+}
+
+void test_stale_opposite_swipe_does_not_trigger_petting() {
+    PettingDetector detector;
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::BACKWARD, 1000));
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::FORWARD, 2600));
+}
+
+void test_detector_resets_after_a_completed_pair() {
+    PettingDetector detector;
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::FORWARD, 1000));
+    TEST_ASSERT_TRUE(detector.observe(TouchSwipeDirection::BACKWARD, 1100));
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::FORWARD, 1200));
+}
+
+void test_window_handles_millis_wraparound() {
+    PettingDetector detector;
+    TEST_ASSERT_FALSE(detector.observe(TouchSwipeDirection::BACKWARD, UINT32_MAX - 500));
+    TEST_ASSERT_TRUE(detector.observe(TouchSwipeDirection::FORWARD, 300));
+}
+
+int main() {
+    UNITY_BEGIN();
+    RUN_TEST(test_single_zone_tap_remains_a_click);
+    RUN_TEST(test_front_to_back_stroke_emits_forward_and_suppresses_release_click);
+    RUN_TEST(test_back_to_front_stroke_emits_backward);
+    RUN_TEST(test_adjacent_zone_round_trip_triggers_petting);
+    RUN_TEST(test_minor_adjacent_zone_crosstalk_does_not_become_a_swipe);
+    RUN_TEST(test_reverse_hysteresis_ignores_one_level_wobble);
+    RUN_TEST(test_continuous_reversal_triggers_petting_without_lifting);
+    RUN_TEST(test_one_way_adjacent_stroke_suppresses_release_click);
+    RUN_TEST(test_equal_edge_contact_does_not_invent_a_direction);
+    RUN_TEST(test_reset_clears_pending_click_suppression);
+    RUN_TEST(test_one_direction_does_not_trigger_petting);
+    RUN_TEST(test_opposite_swipes_inside_window_trigger_petting);
+    RUN_TEST(test_same_direction_does_not_trigger_petting);
+    RUN_TEST(test_latest_same_direction_swipe_starts_a_new_pair_window);
+    RUN_TEST(test_stale_opposite_swipe_does_not_trigger_petting);
+    RUN_TEST(test_detector_resets_after_a_completed_pair);
+    RUN_TEST(test_window_handles_millis_wraparound);
+    return UNITY_END();
+}

--- a/mcp_server/audio_publish.py
+++ b/mcp_server/audio_publish.py
@@ -1,0 +1,42 @@
+import math
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def publish_wav(wav_path: Path, target: str, timeout: float) -> None:
+    """Atomically publish one WAV to a remote rsync destination."""
+    if not target:
+        return
+
+    rsync = shutil.which("rsync")
+    if not rsync:
+        raise RuntimeError("rsync is required when STACKCHAN_AUDIO_PUBLISH_TARGET is set")
+
+    timeout = max(1.0, timeout)
+    destination = target if target.endswith("/") else f"{target}/"
+    ssh_command = (
+        "/usr/bin/ssh -o BatchMode=yes -o ConnectTimeout=6 "
+        "-o ConnectionAttempts=1 -o ServerAliveInterval=3 -o ServerAliveCountMax=2"
+    )
+    try:
+        subprocess.run(  # noqa: S603 - trusted local config, passed as argv without a shell.
+            [
+                rsync,
+                "-a",
+                f"--timeout={math.ceil(timeout)}",
+                "-e",
+                ssh_command,
+                str(wav_path),
+                destination,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"audio publish timed out after {timeout:g}s") from exc
+    except subprocess.CalledProcessError as exc:
+        detail = (exc.stderr or exc.stdout or "rsync failed").strip().splitlines()[-1]
+        raise RuntimeError(f"audio publish failed: {detail}") from exc

--- a/mcp_server/audio_publish.py
+++ b/mcp_server/audio_publish.py
@@ -1,10 +1,55 @@
+import logging
 import math
+import os
 import shutil
+import signal
 import subprocess
+import time
+from contextlib import suppress
 from pathlib import Path
 
+logger = logging.getLogger(__name__)
 
-def publish_wav(wav_path: Path, target: str, timeout: float) -> None:
+
+def _terminate_process_group(process: subprocess.Popen[str]) -> None:
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        process.communicate()
+        return
+
+    try:
+        process.communicate(timeout=1)
+    except subprocess.TimeoutExpired:
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        process.communicate()
+
+
+def _run_publish(command: list[str], timeout: float) -> None:
+    process = subprocess.Popen(  # noqa: S603 - trusted local config, passed as argv without a shell.
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _terminate_process_group(process)
+        raise
+
+    if process.returncode:
+        raise subprocess.CalledProcessError(
+            process.returncode,
+            command,
+            output=stdout,
+            stderr=stderr,
+        )
+
+
+def publish_wav(wav_path: Path, target: str, timeout: float, attempts: int = 2) -> None:
     """Atomically publish one WAV to a remote rsync destination."""
     if not target:
         return
@@ -19,24 +64,39 @@ def publish_wav(wav_path: Path, target: str, timeout: float) -> None:
         "/usr/bin/ssh -o BatchMode=yes -o ConnectTimeout=6 "
         "-o ConnectionAttempts=1 -o ServerAliveInterval=3 -o ServerAliveCountMax=2"
     )
-    try:
-        subprocess.run(  # noqa: S603 - trusted local config, passed as argv without a shell.
-            [
-                rsync,
-                "-a",
-                f"--timeout={math.ceil(timeout)}",
-                "-e",
-                ssh_command,
-                str(wav_path),
-                destination,
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise RuntimeError(f"audio publish timed out after {timeout:g}s") from exc
-    except subprocess.CalledProcessError as exc:
-        detail = (exc.stderr or exc.stdout or "rsync failed").strip().splitlines()[-1]
-        raise RuntimeError(f"audio publish failed: {detail}") from exc
+    command = [
+        rsync,
+        "-a",
+        f"--timeout={math.ceil(timeout)}",
+        "-e",
+        ssh_command,
+        str(wav_path),
+        destination,
+    ]
+    attempts = max(1, attempts)
+    last_error: subprocess.SubprocessError | None = None
+    for attempt in range(1, attempts + 1):
+        try:
+            _run_publish(command, timeout)
+            return
+        except (subprocess.TimeoutExpired, subprocess.CalledProcessError) as exc:
+            last_error = exc
+            if attempt < attempts:
+                logger.warning(
+                    "Audio publish attempt %d/%d failed; retrying: %s",
+                    attempt,
+                    attempts,
+                    exc,
+                )
+                time.sleep(0.5)
+
+    if isinstance(last_error, subprocess.TimeoutExpired):
+        raise RuntimeError(
+            f"audio publish timed out after {attempts} attempts ({timeout:g}s each)"
+        ) from last_error
+    if isinstance(last_error, subprocess.CalledProcessError):
+        detail = (last_error.stderr or last_error.stdout or "rsync failed").strip().splitlines()[-1]
+        raise RuntimeError(
+            f"audio publish failed after {attempts} attempts: {detail}"
+        ) from last_error
+    raise RuntimeError("audio publish failed without a subprocess result")

--- a/mcp_server/mcp_tools.py
+++ b/mcp_server/mcp_tools.py
@@ -8,6 +8,7 @@ from typing import Any
 import requests
 
 from . import audio_processing
+from .audio_publish import publish_wav
 from .audio_server import AUDIO_DIR, audio_url, start_audio_server
 from .listening import capture_ready_recording, format_listen_result
 from .stackchan_client import (
@@ -217,6 +218,14 @@ def register_tools(mcp, client: Any, config: StackchanConfig, image_cls):
             t0 = time.perf_counter()
             audio_processing.validate_playback_wav(wav_path)
             wav_timing["validate"] = timing_ms(t0)
+            if config.audio_publish_target:
+                t0 = time.perf_counter()
+                publish_wav(
+                    wav_path,
+                    config.audio_publish_target,
+                    config.audio_publish_timeout,
+                )
+                wav_timing["publish"] = timing_ms(t0)
             baseline_started_ms = None
             baseline_playing = False
             try:

--- a/mcp_server/mcp_tools.py
+++ b/mcp_server/mcp_tools.py
@@ -251,8 +251,11 @@ def register_tools(mcp, client: Any, config: StackchanConfig, image_cls):
                     wav_timing["playback_wait"] = timing_ms(t0)
                     if not start_result.get("started"):
                         status = start_result.get("status", {})
+                        # 2026/9/2假红教训：队列ack成功后轮询未确认≠没播。
+                        # 高延迟链路(exit node/蜂窝)下短句常在轮询间隙播完。降级为⚠️，不再报❌。
                         return (
-                            "❌ Play was queued but playback did not start: "
+                            "⚠️ Play queued OK; start not confirmed within poll window "
+                            "(likely latency — clip may have already played): "
                             f"kind={status.get('kind', '?')} "
                             f"playing={status.get('playing', '?')} "
                             f"current_bytes={status.get('current_bytes', '?')} "

--- a/mcp_server/mcp_tools.py
+++ b/mcp_server/mcp_tools.py
@@ -224,6 +224,7 @@ def register_tools(mcp, client: Any, config: StackchanConfig, image_cls):
                     wav_path,
                     config.audio_publish_target,
                     config.audio_publish_timeout,
+                    config.audio_publish_attempts,
                 )
                 wav_timing["publish"] = timing_ms(t0)
             baseline_started_ms = None

--- a/mcp_server/stackchan_client.py
+++ b/mcp_server/stackchan_client.py
@@ -175,6 +175,10 @@ class StackchanClient:
             started_ms = last_status.get("started_ms")
             if baseline_started_ms is not None and started_ms != baseline_started_ms:
                 return {"started": True, "status": last_status}
+            # 基线读取失败(None)时的兜底：只要观察到非零started_ms就视为已开始。
+            # 短句在高延迟链路上可能在两次轮询之间开始并结束，只认playing会漏判。
+            if baseline_started_ms is None and started_ms:
+                return {"started": True, "status": last_status, "unconfirmed_baseline": True}
             time.sleep(interval)
         result = {"started": False, "status": last_status}
         if last_error:

--- a/mcp_server/stackchan_config.py
+++ b/mcp_server/stackchan_config.py
@@ -124,6 +124,7 @@ class StackchanConfig:
     mcp_auth_token: str = ""
     audio_publish_target: str = ""
     audio_publish_timeout: float = 20.0
+    audio_publish_attempts: int = 2
 
 
 VALID_AUDIO_MODES = {"auto", "pcm", "wav"}
@@ -162,6 +163,7 @@ def config_summary(config: StackchanConfig) -> dict[str, Any]:
             "save_pcm": config.save_pcm,
             "publish_configured": bool(config.audio_publish_target),
             "publish_timeout": config.audio_publish_timeout,
+            "publish_attempts": config.audio_publish_attempts,
         },
         "pcm": {
             "transport": config.pcm_transport,
@@ -320,5 +322,10 @@ def load_config() -> StackchanConfig:
         audio_publish_timeout=env_float_any(
             ("STACKCHAN_AUDIO_PUBLISH_TIMEOUT", "STACKCHAN_AUDIO_PUBLISH_TIMEOUT_SEC"),
             20.0,
+        ),
+        audio_publish_attempts=clamp_int(
+            env_int("STACKCHAN_AUDIO_PUBLISH_ATTEMPTS", 2),
+            1,
+            3,
         ),
     )

--- a/mcp_server/stackchan_config.py
+++ b/mcp_server/stackchan_config.py
@@ -122,6 +122,8 @@ class StackchanConfig:
     fish_audio_model_zh: str
     fish_audio_model_en: str
     mcp_auth_token: str = ""
+    audio_publish_target: str = ""
+    audio_publish_timeout: float = 20.0
 
 
 VALID_AUDIO_MODES = {"auto", "pcm", "wav"}
@@ -158,6 +160,8 @@ def config_summary(config: StackchanConfig) -> dict[str, Any]:
             "serve_port": config.audio_serve_port,
             "mode": config.audio_mode,
             "save_pcm": config.save_pcm,
+            "publish_configured": bool(config.audio_publish_target),
+            "publish_timeout": config.audio_publish_timeout,
         },
         "pcm": {
             "transport": config.pcm_transport,
@@ -312,4 +316,9 @@ def load_config() -> StackchanConfig:
         fish_audio_model_zh=os.environ.get("FISH_AUDIO_MODEL_ZH", ""),
         fish_audio_model_en=os.environ.get("FISH_AUDIO_MODEL_EN", ""),
         mcp_auth_token=os.environ.get("STACKCHAN_MCP_AUTH_TOKEN", ""),
+        audio_publish_target=os.environ.get("STACKCHAN_AUDIO_PUBLISH_TARGET", ""),
+        audio_publish_timeout=env_float_any(
+            ("STACKCHAN_AUDIO_PUBLISH_TIMEOUT", "STACKCHAN_AUDIO_PUBLISH_TIMEOUT_SEC"),
+            20.0,
+        ),
     )

--- a/scripts/ci_security_audit.py
+++ b/scripts/ci_security_audit.py
@@ -40,6 +40,7 @@ IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 ACTION_USE_RE = re.compile(r"^\s*uses:\s*(?P<target>[^#\s]+)", re.MULTILINE)
 PINNED_ACTION_RE = re.compile(r"@[0-9a-fA-F]{40}$")
 EXACT_PIO_VERSION_RE = re.compile(r"[0-9]+(?:\.[0-9]+)*(?:[-+][A-Za-z0-9.-]+)?")
+GIT_SHA_RE = re.compile(r"[0-9a-f]{40}")
 LOCAL_MACOS_USER_PATH_RE = re.compile(r"/" r"Users/(?!REPLACE_WITH_)[^/\s<]+")
 
 # Retired tunnel hostnames that must never reappear in tracked files. Built from
@@ -243,10 +244,16 @@ def check_platformio_dependency_pins(errors: list[str]) -> None:
 
 
 def has_exact_pio_version(spec: str) -> bool:
-    if "@" not in spec:
-        return False
-    version = spec.rsplit("@", 1)[1].strip()
-    return bool(EXACT_PIO_VERSION_RE.fullmatch(version))
+    # Registry deps: owner/name@<exact semver>.
+    if "@" in spec:
+        version = spec.rsplit("@", 1)[1].strip()
+        return bool(EXACT_PIO_VERSION_RE.fullmatch(version))
+    # VCS deps: <url>#<ref>. Only a full 40-hex commit SHA is immutable;
+    # branch names and tags are rejected on purpose.
+    if "#" in spec:
+        ref = spec.rsplit("#", 1)[1].strip()
+        return bool(GIT_SHA_RE.fullmatch(ref))
+    return False
 
 
 def relpath(path: Path) -> str:

--- a/scripts/stackchan_voice_bridge.py
+++ b/scripts/stackchan_voice_bridge.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 import argparse
+import fcntl
+import hashlib
 import json
 import os
 import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -22,6 +24,41 @@ from scripts.stackchan_frontend_wake import (  # noqa: E402
     forward_to_frontend,
     parse_wake_words,
 )
+
+DEFAULT_TOUCH_PROMPT_PREFIX = "[Stack-chan语音输入] （触摸）"
+TOUCH_PET_TEXT = "[Stack-chan触摸]"
+MAX_TOUCH_PET_EVENTS_PER_POLL = 4
+MAX_TOUCH_PET_BACKLOG = 32
+
+
+class TouchPetTracker:
+    """Turn the firmware's monotonic pet counter into one-shot host events."""
+
+    def __init__(
+        self,
+        max_events_per_poll: int = MAX_TOUCH_PET_EVENTS_PER_POLL,
+        max_backlog: int = MAX_TOUCH_PET_BACKLOG,
+    ):
+        self._last_count: int | None = None
+        self._max_events_per_poll = max(1, max_events_per_poll)
+        self._max_backlog = max(self._max_events_per_poll, max_backlog)
+        self._pending_events = 0
+
+    def observe(self, status: dict[str, Any]) -> int:
+        count = status.get("touch_pet_count")
+        if not isinstance(count, int) or isinstance(count, bool) or count < 0:
+            return 0
+        if self._last_count is None or count < self._last_count:
+            self._last_count = count
+            self._pending_events = 0
+            return 0
+
+        new_events = count - self._last_count
+        self._last_count = count
+        self._pending_events = min(self._pending_events + new_events, self._max_backlog)
+        emitted = min(self._pending_events, self._max_events_per_poll)
+        self._pending_events -= emitted
+        return emitted
 
 
 def load_env_file(path: Path) -> None:
@@ -93,8 +130,67 @@ def print_event(event: dict) -> None:
     print(json.dumps(event, ensure_ascii=False), flush=True)
 
 
+def default_consumer_lock_path(stackchan_ip: str, stackchan_port: int) -> Path:
+    target = f"{stackchan_ip}:{stackchan_port}"
+    target_id = hashlib.sha256(target.encode("utf-8")).hexdigest()[:12]
+    return Path.home() / "Library" / "Caches" / "stackchan" / f"voice-bridge-{target_id}.lock"
+
+
+def acquire_consumer_lock(
+    lock_path: Path,
+    *,
+    wait_interval: float = 5.0,
+    wait: bool = True,
+) -> TextIO | None:
+    """Serialize consumers of Stack-chan's destructive GET /audio endpoint."""
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_handle = lock_path.open("a+", encoding="utf-8")
+    waiting_reported = False
+
+    while True:
+        try:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            break
+        except BlockingIOError:
+            if not wait:
+                print_event(
+                    {
+                        "type": "busy",
+                        "timestamp": utc_now(),
+                        "reason": "another voice bridge owns the audio consumer lock",
+                        "lock_file": str(lock_path),
+                    }
+                )
+                lock_handle.close()
+                return None
+            if not waiting_reported:
+                print_event(
+                    {
+                        "type": "standby",
+                        "timestamp": utc_now(),
+                        "reason": "another voice bridge owns the audio consumer lock",
+                        "lock_file": str(lock_path),
+                    }
+                )
+                waiting_reported = True
+            time.sleep(max(0.1, wait_interval))
+
+    lock_handle.seek(0)
+    lock_handle.truncate()
+    lock_handle.write(f"{os.getpid()}\n")
+    lock_handle.flush()
+    return lock_handle
+
+
 def should_append_to_inbox(event: dict) -> bool:
     return event.get("type") == "transcript" and bool(str(event.get("text") or "").strip())
+
+
+def recording_source_from_result(result: dict[str, Any]) -> str:
+    status = result.get("status")
+    if isinstance(status, dict) and str(status.get("source") or "").lower() == "touch":
+        return "touch"
+    return "voice"
 
 
 def resolve_wake_session(session_id: str, title: str = "") -> str:
@@ -121,6 +217,12 @@ def forward_event_to_frontend(event: dict[str, Any], args: argparse.Namespace) -
         wake_url = "http://127.0.0.1:3200/wake"
     if not wake_url and not wake_session_id:
         return None
+    source = str(event.get("source") or "")
+    is_touch_recording = (
+        str(event.get("recording_source") or "").lower() == "touch"
+        or source == "stackchan_touch"
+    )
+    is_touch_pet = str(event.get("interaction") or "") == "petting"
     return forward_to_frontend(
         event,
         wake_url=wake_url,
@@ -132,10 +234,28 @@ def forward_event_to_frontend(event: dict[str, Any], args: argparse.Namespace) -
         retry_delay=args.wake_retry_delay,
         force=not args.wake_no_force,
         quiet_minutes=args.wake_quiet_minutes,
-        prompt_prefix=args.prompt_prefix,
-        wake_words=parse_wake_words(args.wake_words),
-        source=str(event.get("source") or "stackchan_mic"),
+        prompt_prefix=(
+            ""
+            if is_touch_pet
+            else (
+                getattr(args, "touch_prompt_prefix", DEFAULT_TOUCH_PROMPT_PREFIX)
+                if is_touch_recording
+                else args.prompt_prefix
+            )
+        ),
+        wake_words=() if is_touch_recording or is_touch_pet else parse_wake_words(args.wake_words),
+        source=source or "stackchan_mic",
     )
+
+
+def build_touch_pet_event() -> dict[str, Any]:
+    return {
+        "type": "touch",
+        "source": "stackchan_touch_strip",
+        "interaction": "petting",
+        "timestamp": utc_now(),
+        "text": TOUCH_PET_TEXT,
+    }
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -167,6 +287,21 @@ def build_parser() -> argparse.ArgumentParser:
         "--verbose-idle",
         action="store_true",
         help="Print idle status events when no recording is ready.",
+    )
+    parser.add_argument(
+        "--lock-file",
+        default=os.environ.get("STACKCHAN_VOICE_BRIDGE_LOCKFILE", ""),
+        help=(
+            "Host-local lock that ensures only one bridge consumes GET /audio. "
+            "Defaults to a target-specific file under Library/Caches/stackchan. "
+            "Dry-run probes do not take the lock."
+        ),
+    )
+    parser.add_argument(
+        "--lock-wait-interval",
+        type=float,
+        default=float(os.environ.get("STACKCHAN_VOICE_BRIDGE_LOCK_WAIT", "5")),
+        help="Seconds a standby bridge waits before retrying the consumer lock.",
     )
     parser.add_argument(
         "--inbox",
@@ -225,6 +360,11 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.environ.get("STACKCHAN_FRONTEND_PROMPT_PREFIX", DEFAULT_PROMPT_PREFIX),
     )
     parser.add_argument(
+        "--touch-prompt-prefix",
+        default=os.environ.get("STACKCHAN_TOUCH_PROMPT_PREFIX", DEFAULT_TOUCH_PROMPT_PREFIX),
+        help="Prefix for touch-triggered transcripts. These recordings bypass wake-word matching.",
+    )
+    parser.add_argument(
         "--wake-words",
         default=os.environ.get("STACKCHAN_VOICE_WAKE_WORDS", ""),
         help=(
@@ -246,10 +386,32 @@ def main() -> int:
     config = load_config()
     client = StackchanClient(config)
     consumed = 0
+    touch_pet_tracker = TouchPetTracker()
     inbox_path = None if args.no_inbox else resolve_inbox_path(args.inbox)
+    # Keep the descriptor reachable for the whole polling loop. Process exit
+    # releases the advisory lock even when launchd terminates the bridge.
+    _consumer_lock = None
+    if not args.dry_run:
+        lock_path = (
+            Path(args.lock_file).expanduser()
+            if args.lock_file
+            else default_consumer_lock_path(config.stackchan_ip, config.stackchan_port)
+        )
+        try:
+            _consumer_lock = acquire_consumer_lock(
+                lock_path,
+                wait_interval=args.lock_wait_interval,
+                wait=not args.once,
+            )
+        except KeyboardInterrupt:
+            print_event({"type": "stop", "timestamp": utc_now(), "reason": "keyboard_interrupt"})
+            return 0
+        if _consumer_lock is None:
+            return 2
 
     while True:
         try:
+            touch_pet_events = 0
             if args.dry_run:
                 status = client.audio_status()
                 event = {
@@ -260,11 +422,14 @@ def main() -> int:
                 }
             else:
                 result = capture_ready_recording(client, config, lang=args.lang)
+                touch_pet_events = touch_pet_tracker.observe(result.get("status", {}))
                 if result.get("ready") and result.get("consumed"):
                     consumed += 1
+                    recording_source = recording_source_from_result(result)
                     event = {
                         "type": "transcript",
-                        "source": "stackchan_mic",
+                        "source": "stackchan_touch" if recording_source == "touch" else "stackchan_mic",
+                        "recording_source": recording_source,
                         "timestamp": utc_now(),
                         "lang": args.lang,
                         "text": result.get("text", ""),
@@ -292,6 +457,13 @@ def main() -> int:
 
             if event is not None:
                 print_event(event)
+
+            for _ in range(touch_pet_events):
+                touch_event = build_touch_pet_event()
+                frontend = forward_event_to_frontend(touch_event, args)
+                if frontend is not None:
+                    touch_event["frontend"] = frontend
+                print_event(touch_event)
 
             if args.once or (args.max_events and consumed >= args.max_events):
                 return 0

--- a/scripts/stackchan_voice_bridge.py
+++ b/scripts/stackchan_voice_bridge.py
@@ -47,15 +47,13 @@ def load_env_file(path: Path) -> None:
         os.environ[key] = value
 
 
-def load_frontend_token() -> None:
-    if os.environ.get("STACKCHAN_FRONTEND_TOKEN"):
-        return
+def read_frontend_token_file() -> str:
     env_path_raw = os.environ.get("STACKCHAN_FRONTEND_ENV", "")
     if not env_path_raw:
-        return
+        return ""
     env_path = Path(env_path_raw)
     if not env_path.exists():
-        return
+        return ""
 
     for raw_line in env_path.read_text().splitlines():
         line = raw_line.strip()
@@ -68,8 +66,23 @@ def load_frontend_token() -> None:
         if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
             value = value[1:-1]
         if value:
-            os.environ["STACKCHAN_FRONTEND_TOKEN"] = value
+            return value
+        return ""
+    return ""
+
+
+def load_frontend_token() -> None:
+    if os.environ.get("STACKCHAN_FRONTEND_TOKEN"):
         return
+    value = read_frontend_token_file()
+    if value:
+        os.environ["STACKCHAN_FRONTEND_TOKEN"] = value
+
+
+def resolve_frontend_token(configured_token: str = "") -> str:
+    if configured_token:
+        return configured_token
+    return read_frontend_token_file() or os.environ.get("STACKCHAN_FRONTEND_TOKEN", "")
 
 
 def utc_now() -> str:
@@ -112,7 +125,7 @@ def forward_event_to_frontend(event: dict[str, Any], args: argparse.Namespace) -
         event,
         wake_url=wake_url,
         session_id=wake_session_id,
-        token=args.wake_token,
+        token=resolve_frontend_token(args.wake_token),
         model=args.wake_model,
         timeout=args.wake_timeout,
         retries=args.wake_retries,
@@ -229,7 +242,6 @@ def main() -> int:
     from mcp_server.voice_inbox import append_event, resolve_inbox_path
 
     load_env_file(REPO_ROOT / ".env")
-    load_frontend_token()
     args = build_parser().parse_args()
     config = load_config()
     client = StackchanClient(config)

--- a/scripts/stackchan_voice_upload_server.py
+++ b/scripts/stackchan_voice_upload_server.py
@@ -36,7 +36,7 @@ from scripts.stackchan_frontend_wake import (  # noqa: E402
 )
 from scripts.stackchan_voice_bridge import (  # noqa: E402
     load_env_file,
-    load_frontend_token,
+    resolve_frontend_token,
     resolve_wake_session,
     should_append_to_inbox,
 )
@@ -685,7 +685,7 @@ class VoiceUploadHandler(BaseHTTPRequestHandler):
                 event,
                 wake_url=self.voice_server.options.wake_url,
                 session_id=wake_session_id,
-                token=self.voice_server.options.wake_token,
+                token=resolve_frontend_token(self.voice_server.options.wake_token),
                 model=self.voice_server.options.wake_model,
                 timeout=self.voice_server.options.wake_timeout,
                 retries=self.voice_server.options.wake_retries,
@@ -852,7 +852,6 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main() -> int:
     load_env_file(REPO_ROOT / ".env")
-    load_frontend_token()
     parser = build_parser()
     args = parser.parse_args()
     config = load_config()

--- a/scripts/stackchan_voice_upload_server.py
+++ b/scripts/stackchan_voice_upload_server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import hmac
 import html
 import ipaddress
 import json
@@ -17,7 +18,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from threading import Lock
 from typing import Any, cast
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -481,13 +482,14 @@ def process_uploaded_wav(
 def is_upload_authorized(path: str, headers: Any, token: str) -> bool:
     if not token:
         return True
-    url = urlparse(path)
-    query_token = parse_qs(url.query).get("token", [""])[0]
     auth = headers.get("Authorization", "")
     header_token = headers.get("X-Stackchan-Upload-Token", "")
-    # `?token=` remains accepted for existing bookmarked URLs, but new clients
-    # should prefer the header-based flow so tokens do not linger in URLs.
-    return query_token == token or auth == f"Bearer {token}" or header_token == token
+    bearer_token = auth.removeprefix("Bearer ") if auth.startswith("Bearer ") else ""
+
+    def matches(candidate: str) -> bool:
+        return bool(candidate) and hmac.compare_digest(candidate.encode(), token.encode())
+
+    return matches(bearer_token) or matches(header_token)
 
 
 def build_health_payload(options: ServerOptions) -> dict[str, Any]:
@@ -822,7 +824,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=os.environ.get("STACKCHAN_VOICE_UPLOAD_TOKEN", ""),
         help=(
             "Optional token required for POST /voice/upload. The recorder page sends it as "
-            "X-Stackchan-Upload-Token; ?token=... is accepted only for backward compatibility."
+            "X-Stackchan-Upload-Token. Query-string tokens are never accepted for uploads."
         ),
     )
     parser.add_argument(

--- a/tests/test_audio_publish.py
+++ b/tests/test_audio_publish.py
@@ -1,0 +1,103 @@
+import subprocess
+
+import pytest
+
+from mcp_server.audio_publish import publish_wav
+from mcp_server.mcp_tools import register_tools
+from mcp_server.stackchan_config import load_config
+
+
+def test_publish_wav_waits_for_one_file(monkeypatch, tmp_path):
+    wav_path = tmp_path / "speech.wav"
+    wav_path.write_bytes(b"RIFF")
+    calls = []
+
+    monkeypatch.setattr("mcp_server.audio_publish.shutil.which", lambda _name: "/usr/bin/rsync")
+    monkeypatch.setattr(
+        "mcp_server.audio_publish.subprocess.run",
+        lambda command, **kwargs: calls.append((command, kwargs)),
+    )
+
+    publish_wav(wav_path, "macbook-isa:stackchan_audio", 12.5)
+
+    command, kwargs = calls[0]
+    assert command[0] == "/usr/bin/rsync"
+    assert command[1:3] == ["-a", "--timeout=13"]
+    assert command[-2:] == [str(wav_path), "macbook-isa:stackchan_audio/"]
+    assert kwargs == {
+        "check": True,
+        "capture_output": True,
+        "text": True,
+        "timeout": 12.5,
+    }
+
+
+def test_publish_wav_reports_timeout(monkeypatch, tmp_path):
+    wav_path = tmp_path / "speech.wav"
+    wav_path.write_bytes(b"RIFF")
+    monkeypatch.setattr("mcp_server.audio_publish.shutil.which", lambda _name: "/usr/bin/rsync")
+    monkeypatch.setattr(
+        "mcp_server.audio_publish.subprocess.run",
+        lambda command, **_kwargs: (_ for _ in ()).throw(
+            subprocess.TimeoutExpired(command, 3)
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="audio publish timed out after 3s"):
+        publish_wav(wav_path, "macbook-isa:stackchan_audio/", 3)
+
+
+def test_audio_publish_config_is_optional_and_read_from_env(monkeypatch):
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
+    monkeypatch.setenv("STACKCHAN_AUDIO_PUBLISH_TARGET", "macbook-isa:stackchan_audio/")
+    monkeypatch.setenv("STACKCHAN_AUDIO_PUBLISH_TIMEOUT_SEC", "17")
+
+    config = load_config()
+
+    assert config.audio_publish_target == "macbook-isa:stackchan_audio/"
+    assert config.audio_publish_timeout == 17
+
+
+def test_stackchan_say_publishes_before_play(monkeypatch, tmp_path):
+    wav_path = tmp_path / "speech.wav"
+    wav_path.write_bytes(b"RIFF")
+    events = []
+
+    class FakeMcp:
+        def __init__(self):
+            self.tools = {}
+
+        def tool(self, **_kwargs):
+            def decorator(func):
+                self.tools[func.__name__] = func
+                return func
+
+            return decorator
+
+    class FakeClient:
+        def playback_status(self):
+            return {"playing": False, "started_ms": 1}
+
+        def play(self, _url):
+            events.append("play")
+            return {"success": True}
+
+        def wait_for_playback_start(self, baseline_started_ms=None):
+            return {"started": True, "status": {"started_ms": baseline_started_ms}}
+
+    monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
+    monkeypatch.setenv("STACKCHAN_AUDIO_MODE", "wav")
+    monkeypatch.setenv("STACKCHAN_AUDIO_PUBLISH_TARGET", "macbook-isa:stackchan_audio/")
+    monkeypatch.setattr("mcp_server.mcp_tools.start_audio_server", lambda _port: None)
+    monkeypatch.setattr("mcp_server.audio_processing.generate_tts", lambda *_args, **_kwargs: wav_path)
+    monkeypatch.setattr("mcp_server.audio_processing.validate_playback_wav", lambda _path: None)
+    monkeypatch.setattr(
+        "mcp_server.mcp_tools.publish_wav",
+        lambda *_args, **_kwargs: events.append("publish"),
+    )
+
+    mcp = FakeMcp()
+    register_tools(mcp, FakeClient(), load_config(), image_cls=None)
+
+    assert "Stack-chan is saying" in mcp.tools["stackchan_say"]("hello", lang="en")
+    assert events == ["publish", "play"]

--- a/tests/test_audio_publish.py
+++ b/tests/test_audio_publish.py
@@ -1,4 +1,6 @@
+import signal
 import subprocess
+from dataclasses import dataclass
 
 import pytest
 
@@ -12,10 +14,19 @@ def test_publish_wav_waits_for_one_file(monkeypatch, tmp_path):
     wav_path.write_bytes(b"RIFF")
     calls = []
 
+    @dataclass
+    class FakeProcess:
+        pid: int = 100
+        returncode: int = 0
+
+        def communicate(self, timeout=None):
+            calls.append(("communicate", timeout))
+            return "", ""
+
     monkeypatch.setattr("mcp_server.audio_publish.shutil.which", lambda _name: "/usr/bin/rsync")
     monkeypatch.setattr(
-        "mcp_server.audio_publish.subprocess.run",
-        lambda command, **kwargs: calls.append((command, kwargs)),
+        "mcp_server.audio_publish.subprocess.Popen",
+        lambda command, **kwargs: calls.append((command, kwargs)) or FakeProcess(),
     )
 
     publish_wav(wav_path, "macbook-isa:stackchan_audio", 12.5)
@@ -25,37 +36,105 @@ def test_publish_wav_waits_for_one_file(monkeypatch, tmp_path):
     assert command[1:3] == ["-a", "--timeout=13"]
     assert command[-2:] == [str(wav_path), "macbook-isa:stackchan_audio/"]
     assert kwargs == {
-        "check": True,
-        "capture_output": True,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
         "text": True,
-        "timeout": 12.5,
+        "start_new_session": True,
     }
+    assert calls[1] == ("communicate", 12.5)
 
 
-def test_publish_wav_reports_timeout(monkeypatch, tmp_path):
+def test_publish_wav_retries_timeout_and_terminates_process_group(monkeypatch, tmp_path):
     wav_path = tmp_path / "speech.wav"
     wav_path.write_bytes(b"RIFF")
     monkeypatch.setattr("mcp_server.audio_publish.shutil.which", lambda _name: "/usr/bin/rsync")
+    calls = []
+
+    class FakeProcess:
+        def __init__(self, attempt):
+            self.attempt = attempt
+            self.pid = 100 + attempt
+            self.returncode = 0
+            self.communicate_calls = 0
+
+        def communicate(self, timeout=None):
+            self.communicate_calls += 1
+            calls.append(("communicate", self.attempt, timeout))
+            if self.communicate_calls == 1:
+                raise subprocess.TimeoutExpired(["rsync"], 3)
+            return "", ""
+
+    processes = []
+
+    def fake_popen(*_args, **_kwargs):
+        process = FakeProcess(len(processes) + 1)
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr("mcp_server.audio_publish.subprocess.Popen", fake_popen)
     monkeypatch.setattr(
-        "mcp_server.audio_publish.subprocess.run",
-        lambda command, **_kwargs: (_ for _ in ()).throw(
-            subprocess.TimeoutExpired(command, 3)
-        ),
+        "mcp_server.audio_publish.os.killpg",
+        lambda pid, sig: calls.append(("killpg", pid, sig)),
+    )
+    monkeypatch.setattr(
+        "mcp_server.audio_publish.time.sleep",
+        lambda delay: calls.append(("sleep", delay)),
     )
 
-    with pytest.raises(RuntimeError, match="audio publish timed out after 3s"):
+    with pytest.raises(RuntimeError, match=r"audio publish timed out after 2 attempts \(3s each\)"):
         publish_wav(wav_path, "macbook-isa:stackchan_audio/", 3)
+
+    assert len(processes) == 2
+    assert ("killpg", 101, signal.SIGTERM) in calls
+    assert ("killpg", 102, signal.SIGTERM) in calls
+    assert ("sleep", 0.5) in calls
+
+
+def test_publish_wav_succeeds_on_retry(monkeypatch, tmp_path):
+    wav_path = tmp_path / "speech.wav"
+    wav_path.write_bytes(b"RIFF")
+    monkeypatch.setattr("mcp_server.audio_publish.shutil.which", lambda _name: "/usr/bin/rsync")
+    processes = []
+
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, attempt):
+            self.attempt = attempt
+            self.pid = 200 + attempt
+            self.communicate_calls = 0
+
+        def communicate(self, timeout=None):
+            self.communicate_calls += 1
+            if self.attempt == 1 and self.communicate_calls == 1:
+                raise subprocess.TimeoutExpired(["rsync"], timeout)
+            return "", ""
+
+    def fake_popen(*_args, **_kwargs):
+        process = FakeProcess(len(processes) + 1)
+        processes.append(process)
+        return process
+
+    monkeypatch.setattr("mcp_server.audio_publish.subprocess.Popen", fake_popen)
+    monkeypatch.setattr("mcp_server.audio_publish.os.killpg", lambda *_args: None)
+    monkeypatch.setattr("mcp_server.audio_publish.time.sleep", lambda _delay: None)
+
+    publish_wav(wav_path, "macbook-isa:stackchan_audio/", 3)
+
+    assert len(processes) == 2
 
 
 def test_audio_publish_config_is_optional_and_read_from_env(monkeypatch):
     monkeypatch.setattr("mcp_server.stackchan_config.load_dotenv", lambda path=None: None)
     monkeypatch.setenv("STACKCHAN_AUDIO_PUBLISH_TARGET", "macbook-isa:stackchan_audio/")
     monkeypatch.setenv("STACKCHAN_AUDIO_PUBLISH_TIMEOUT_SEC", "17")
+    monkeypatch.setenv("STACKCHAN_AUDIO_PUBLISH_ATTEMPTS", "3")
 
     config = load_config()
 
     assert config.audio_publish_target == "macbook-isa:stackchan_audio/"
     assert config.audio_publish_timeout == 17
+    assert config.audio_publish_attempts == 3
 
 
 def test_stackchan_say_publishes_before_play(monkeypatch, tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -53,9 +53,14 @@ from scripts import (
     stackchan_voice_upload_server,
 )
 from scripts.stackchan_voice_bridge import (
+    TouchPetTracker,
+    acquire_consumer_lock,
+    build_touch_pet_event,
+    default_consumer_lock_path,
     forward_event_to_frontend,
     load_env_file,
     load_frontend_token,
+    recording_source_from_result,
     resolve_frontend_token,
     should_append_to_inbox,
 )
@@ -630,6 +635,166 @@ def test_voice_bridge_only_appends_non_empty_transcripts_to_inbox():
     assert not should_append_to_inbox({"type": "transcript", "text": ""})
     assert not should_append_to_inbox({"type": "transcript", "text": "   "})
     assert not should_append_to_inbox({"type": "idle", "text": "小记，你好。"})
+
+
+def test_voice_bridge_reads_touch_source_from_audio_status():
+    assert recording_source_from_result({"status": {"source": "touch"}}) == "touch"
+    assert recording_source_from_result({"status": {"source": "voice"}}) == "voice"
+    assert recording_source_from_result({"status": {}}) == "voice"
+
+
+def test_voice_bridge_touch_recording_bypasses_wake_word_and_uses_touch_prefix(monkeypatch):
+    forwarded = {}
+
+    def fake_forward(event, **kwargs):
+        forwarded["event"] = event
+        forwarded.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr("scripts.stackchan_voice_bridge.forward_to_frontend", fake_forward)
+    args = argparse.Namespace(
+        wake_session_id="117067d6-1111-2222-3333-444444444444",
+        wake_session_title="",
+        wake_url="http://127.0.0.1:3200/wake",
+        wake_token="agent-token",
+        wake_model="",
+        wake_timeout=3,
+        wake_retries=0,
+        wake_retry_delay=0,
+        wake_no_force=False,
+        wake_quiet_minutes=0,
+        prompt_prefix="[Stack-chan语音输入] ",
+        touch_prompt_prefix="[Stack-chan语音输入] （触摸）",
+        wake_words="小塔,机器人",
+    )
+    event = {
+        "type": "transcript",
+        "source": "stackchan_touch",
+        "recording_source": "touch",
+        "text": "不带唤醒词也要送达",
+    }
+
+    result = forward_event_to_frontend(event, args)
+
+    assert result == {"ok": True}
+    assert forwarded["event"] == event
+    assert forwarded["prompt_prefix"] == "[Stack-chan语音输入] （触摸）"
+    assert forwarded["wake_words"] == ()
+    assert forwarded["source"] == "stackchan_touch"
+
+
+def test_touch_pet_tracker_emits_only_new_counts_and_rebaselines_after_restart():
+    tracker = TouchPetTracker()
+
+    assert tracker.observe({"touch_pet_count": 7}) == 0
+    assert tracker.observe({"touch_pet_count": 7}) == 0
+    assert tracker.observe({"touch_pet_count": 9}) == 2
+    assert tracker.observe({"touch_pet_count": 1}) == 0
+    assert tracker.observe({"touch_pet_count": 2}) == 1
+    assert tracker.observe({}) == 0
+
+
+def test_touch_pet_tracker_drains_a_counter_jump_across_polls():
+    tracker = TouchPetTracker(max_events_per_poll=3)
+
+    assert tracker.observe({"touch_pet_count": 1}) == 0
+    assert tracker.observe({"touch_pet_count": 7}) == 3
+    assert tracker.observe({"touch_pet_count": 7}) == 3
+    assert tracker.observe({"touch_pet_count": 7}) == 0
+
+
+def test_touch_pet_tracker_bounds_a_corrupt_or_stale_counter_jump():
+    tracker = TouchPetTracker(max_events_per_poll=3, max_backlog=6)
+
+    assert tracker.observe({"touch_pet_count": 1}) == 0
+    assert tracker.observe({"touch_pet_count": 100}) == 3
+    assert tracker.observe({"touch_pet_count": 100}) == 3
+    assert tracker.observe({"touch_pet_count": 100}) == 0
+
+
+def test_voice_bridge_forwards_touch_pet_without_prefix_or_wake_word(monkeypatch):
+    forwarded = {}
+
+    def fake_forward(event, **kwargs):
+        forwarded["event"] = event
+        forwarded.update(kwargs)
+        return {"ok": True}
+
+    monkeypatch.setattr("scripts.stackchan_voice_bridge.forward_to_frontend", fake_forward)
+    args = argparse.Namespace(
+        wake_session_id="117067d6-1111-2222-3333-444444444444",
+        wake_session_title="",
+        wake_url="http://127.0.0.1:3200/wake",
+        wake_token="agent-token",
+        wake_model="",
+        wake_timeout=3,
+        wake_retries=0,
+        wake_retry_delay=0,
+        wake_no_force=False,
+        wake_quiet_minutes=0,
+        prompt_prefix="[Stack-chan语音输入] ",
+        touch_prompt_prefix="[Stack-chan语音输入] （触摸）",
+        wake_words="小塔,机器人",
+    )
+    event = build_touch_pet_event()
+
+    result = forward_event_to_frontend(event, args)
+
+    assert result == {"ok": True}
+    assert forwarded["event"] == event
+    assert forwarded["prompt_prefix"] == ""
+    assert forwarded["wake_words"] == ()
+    assert forwarded["source"] == "stackchan_touch_strip"
+
+
+def test_voice_bridge_consumer_lock_waits_then_records_owner(monkeypatch, tmp_path, capsys):
+    lock_path = tmp_path / "voice-bridge.lock"
+    attempts = 0
+
+    def fake_flock(_fd, _flags):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise BlockingIOError
+
+    monkeypatch.setattr("scripts.stackchan_voice_bridge.fcntl.flock", fake_flock)
+    monkeypatch.setattr("scripts.stackchan_voice_bridge.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("scripts.stackchan_voice_bridge.os.getpid", lambda: 4242)
+
+    lock_handle = acquire_consumer_lock(lock_path, wait_interval=0)
+    try:
+        assert attempts == 2
+        assert lock_path.read_text(encoding="utf-8") == "4242\n"
+        standby = json.loads(capsys.readouterr().out)
+        assert standby["type"] == "standby"
+        assert standby["lock_file"] == str(lock_path)
+    finally:
+        lock_handle.close()
+
+
+def test_voice_bridge_consumer_lock_can_fail_fast(monkeypatch, tmp_path, capsys):
+    lock_path = tmp_path / "voice-bridge.lock"
+    monkeypatch.setattr(
+        "scripts.stackchan_voice_bridge.fcntl.flock",
+        lambda _fd, _flags: (_ for _ in ()).throw(BlockingIOError()),
+    )
+
+    assert acquire_consumer_lock(lock_path, wait=False) is None
+    busy = json.loads(capsys.readouterr().out)
+    assert busy["type"] == "busy"
+    assert busy["lock_file"] == str(lock_path)
+
+
+def test_voice_bridge_default_lock_is_namespaced_by_target(monkeypatch, tmp_path):
+    monkeypatch.setattr("scripts.stackchan_voice_bridge.Path.home", lambda: tmp_path)
+
+    first = default_consumer_lock_path("192.0.2.10", 80)
+    same = default_consumer_lock_path("192.0.2.10", 80)
+    second = default_consumer_lock_path("192.0.2.11", 80)
+
+    assert first == same
+    assert first != second
+    assert first.parent == tmp_path / "Library" / "Caches" / "stackchan"
 
 
 def test_voice_upload_processes_wav_into_transcript_event(monkeypatch, tmp_path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -759,7 +759,7 @@ def test_voice_upload_token_authorization():
         {},
         "secret-token",
     )
-    assert stackchan_voice_upload_server.is_upload_authorized(
+    assert not stackchan_voice_upload_server.is_upload_authorized(
         "/voice/upload?token=secret-token",
         {},
         "secret-token",
@@ -772,6 +772,11 @@ def test_voice_upload_token_authorization():
     assert stackchan_voice_upload_server.is_upload_authorized(
         "/voice/upload",
         {"X-Stackchan-Upload-Token": "secret-token"},
+        "secret-token",
+    )
+    assert not stackchan_voice_upload_server.is_upload_authorized(
+        "/voice/upload",
+        {"Authorization": "Basic secret-token"},
         "secret-token",
     )
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -56,6 +56,7 @@ from scripts.stackchan_voice_bridge import (
     forward_event_to_frontend,
     load_env_file,
     load_frontend_token,
+    resolve_frontend_token,
     should_append_to_inbox,
 )
 
@@ -608,6 +609,20 @@ def test_voice_bridge_loads_frontend_token_from_agent_host_env(monkeypatch, tmp_
     load_frontend_token()
 
     assert os.environ["STACKCHAN_FRONTEND_TOKEN"] == "agent-secret"
+
+
+def test_voice_bridge_reloads_rotated_frontend_token(monkeypatch, tmp_path):
+    env_path = tmp_path / "relay.env"
+    env_path.write_text("AGENT_HOST_TOKEN=first-token\n", encoding="utf-8")
+    monkeypatch.delenv("STACKCHAN_FRONTEND_TOKEN", raising=False)
+    monkeypatch.setenv("STACKCHAN_FRONTEND_ENV", str(env_path))
+
+    assert resolve_frontend_token() == "first-token"
+
+    env_path.write_text("AGENT_HOST_TOKEN=rotated-token\n", encoding="utf-8")
+
+    assert resolve_frontend_token() == "rotated-token"
+    assert resolve_frontend_token("explicit-token") == "explicit-token"
 
 
 def test_voice_bridge_only_appends_non_empty_transcripts_to_inbox():


### PR DESCRIPTION
Ten commits accumulated on `env-sensor` after #21 merged. All are deployed and running in production on the household unit; `pytest` passes (110 tests).

**Firmware**
- `d4ab2c7` feat: touch interaction (short-touch = wake-word-free talk; swipe = tap notification) + runtime recovery
- `23c59b4` fix: recover interrupted wav downloads
- `0635518` fix: recover microphone capture
- `58034ca` fix: disable lip-sync GIF switching that flickered the face mid-speech

**MCP / audio path**
- `458446b` fix: publish remote wav before playback
- `b56af75` fix: retry transient audio publish failures (cellular/relay links)
- `83a1e5f` fix(say): stop reporting a false ❌ when playback start is unconfirmed — on high-latency links (Tailscale exit node, hotspot) short clips start and finish between status polls; the queue ack is the reliable signal, the poll is best-effort. Four such ❌ on 2026-09-02 all corresponded to clips that actually played.

**Voice upload**
- `48eaf5e` fix: harden upload token authentication
- `9526e8c` fix: refresh rotated relay token

**Housekeeping**
- `db14d88` chore: gitignore a household-specific relay helper (contains private IPs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)