### PR TITLE
feat(firmware): preview camera snapshots on display

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Stack-chan takes a photo, returns it to the AI, and the AI describes what it fou
 |------|-------------|
 | `stackchan_say` | Speak text through the speaker (Fish Audio TTS or edge-tts fallback) |
 | `stackchan_listen` | Record from mic + transcribe (Groq Whisper via Fish Audio ASR) |
-| `stackchan_see` | Capture a photo from the 320x240 GC0308 camera |
+| `stackchan_see` | Capture a photo and preview the same frame on Stack-chan's display for six seconds |
 | `stackchan_face` | Set expression: `calm` `thinking` `happy` `sleepy` `shy` `smug` `pouty` |
 | `stackchan_sense` | Read temperature, humidity, and barometric pressure (ENV III Unit) |
 | `stackchan_move` | Move head: pan −128 to +128, tilt 0 to 90 |

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -172,7 +172,7 @@ The firmware exposes an HTTP API on port 80.
 | `GET` | `/playback/status` | Runtime diagnostics | Playback, PCM queues, mic state, gesture, heap, and PSRAM |
 | `POST` | `/face` | Set face expression | Body: `{"face":"calm"}` |
 | `GET` | `/face` | Read current face expression | Returns current face name |
-| `GET` | `/snapshot` | Capture camera image | Returns 320x240 JPEG |
+| `GET` | `/snapshot` | Capture camera image | Returns a 320x240 JPEG and previews it on the display for six seconds |
 
 Supported face names are `calm`, `thinking`, `happy`, `sleepy`, `shy`, `smug`,
 and `pouty`.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -122,4 +122,7 @@ This is the shared contract between the CoreS3 firmware and the MCP server.
   - `download_age_ms` reports the age of the active WAV download, or `0` when
     idle. `download_watchdog_ms` reports the automatic recovery threshold.
 - `GET /snapshot`
-  - Returns a JPEG image.
+  - Returns a 320x240 JPEG image.
+  - Shows that same JPEG on Stack-chan's display for six seconds, then redraws
+    the latest requested face. A display-preview failure does not fail the
+    camera response.

--- a/firmware/src/face_service.cpp
+++ b/firmware/src/face_service.cpp
@@ -7,6 +7,9 @@
 #include <AnimatedGIF.h>
 #include <M5Unified.h>
 #include <SPIFFS.h>
+#include <atomic>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
 
 // ── GIF engine state ───────────────────────────────────────────────────────
 static AnimatedGIF gif;
@@ -15,6 +18,13 @@ static size_t         current_gif_len    = 0;
 static volatile bool  gif_changed        = false;
 static int            gif_src_width      = 0;
 static int            gif_src_height     = 0;
+static SemaphoreHandle_t display_mutex    = nullptr;
+
+// The HTTP server runs on the Arduino loop task while GIF rendering runs on
+// core 1. A short preview gate and display mutex keep both from drawing at
+// once, then force the newest face state to be redrawn when the preview ends.
+static std::atomic<bool>     camera_preview_active{false};
+static std::atomic<uint32_t> camera_preview_until_ms{0};
 
 // ── Face tracking ──────────────────────────────────────────────────────────
 static WhaleFace currentFace = WHALE_CALM;
@@ -54,6 +64,20 @@ static const int NUM_GIF_ASSETS = 7;
 // We use fixed-point: scale_num=5, scale_den=4 (= 1.25x).
 #define SCALE_NUM 5
 #define SCALE_DEN 4
+
+static bool previewDeadlineReached(uint32_t now, uint32_t deadline) {
+    return static_cast<int32_t>(now - deadline) >= 0;
+}
+
+static bool takeDisplay(TickType_t timeout) {
+    return display_mutex == nullptr || xSemaphoreTake(display_mutex, timeout) == pdTRUE;
+}
+
+static void releaseDisplay() {
+    if (display_mutex != nullptr) {
+        xSemaphoreGive(display_mutex);
+    }
+}
 
 static void GIFDraw(GIFDRAW* pDraw) {
     int srcW = pDraw->iWidth;
@@ -113,8 +137,32 @@ static void faceTask(void* param) {
     gif.begin(GIF_PALETTE_RGB565_LE);
 
     while (true) {
+        if (camera_preview_active.load()) {
+            const uint32_t deadline = camera_preview_until_ms.load();
+            if (!previewDeadlineReached(millis(), deadline)) {
+                vTaskDelay(pdMS_TO_TICKS(25));
+                continue;
+            }
+
+            camera_preview_active.store(false);
+            gif_changed = true;
+        }
+
         if (gif_changed) {
             gif.close();
+
+            if (!takeDisplay(portMAX_DELAY)) {
+                vTaskDelay(pdMS_TO_TICKS(25));
+                continue;
+            }
+
+            // A preview may have started while this task was waiting for the
+            // display. Leave the GIF closed and retry after the preview.
+            if (camera_preview_active.load()) {
+                releaseDisplay();
+                continue;
+            }
+
             M5.Display.fillScreen(TFT_BLACK);
 
             if (current_gif_data != nullptr) {
@@ -133,14 +181,28 @@ static void faceTask(void* param) {
                 }
             }
             gif_changed = false;
+            releaseDisplay();
         }
 
         if (current_gif_data != nullptr) {
+            if (!takeDisplay(portMAX_DELAY)) {
+                vTaskDelay(pdMS_TO_TICKS(25));
+                continue;
+            }
+
+            // Recheck after acquiring the display so a camera preview cannot
+            // be immediately overwritten by a GIF frame.
+            if (camera_preview_active.load()) {
+                releaseDisplay();
+                continue;
+            }
+
             int frameResult = gif.playFrame(true, nullptr);
             if (frameResult == 0) {
                 // End of animation — reset to loop.
                 gif.reset();
             }
+            releaseDisplay();
         } else {
             vTaskDelay(pdMS_TO_TICKS(50));
         }
@@ -171,6 +233,11 @@ void initFace() {
     current_gif_len  = GIF_ASSETS[WHALE_CALM].len;
     gif_changed      = true;
     currentFace      = WHALE_CALM;
+
+    display_mutex = xSemaphoreCreateMutex();
+    if (display_mutex == nullptr) {
+        Serial.println("[FACE] Display mutex allocation failed; camera preview disabled");
+    }
 
     // Spawn animation task on core 1 (core 0 handles WiFi/BT).
     xTaskCreatePinnedToCore(faceTask, "face_gif", 8192, nullptr, 1, nullptr, 1);
@@ -235,4 +302,39 @@ const char* getCurrentFaceName() {
 
 uint32_t getFaceCommandRevision() {
     return faceCommandRevision;
+}
+
+bool showCameraPreview(const uint8_t* jpegData, size_t jpegLen, uint32_t durationMs) {
+    if (jpegData == nullptr || jpegLen == 0 || display_mutex == nullptr) {
+        return false;
+    }
+
+    camera_preview_until_ms.store(millis() + durationMs);
+    camera_preview_active.store(true);
+
+    if (!takeDisplay(pdMS_TO_TICKS(2000))) {
+        camera_preview_active.store(false);
+        gif_changed = true;
+        Serial.println("[FACE] Camera preview timed out waiting for display");
+        return false;
+    }
+
+    const bool drawn = M5.Display.drawJpg(
+        jpegData,
+        static_cast<uint32_t>(jpegLen),
+        0,
+        0,
+        M5.Display.width(),
+        M5.Display.height());
+    releaseDisplay();
+
+    if (!drawn) {
+        camera_preview_active.store(false);
+        gif_changed = true;
+        Serial.println("[FACE] Camera preview JPEG decode failed");
+        return false;
+    }
+
+    Serial.printf("[FACE] Camera preview shown for %u ms\n", (unsigned)durationMs);
+    return true;
 }

--- a/firmware/src/face_service.h
+++ b/firmware/src/face_service.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "face_names.h"
@@ -21,3 +22,8 @@ const char* getCurrentFaceName();
 // Advances on every face command, including a same-face reassertion. This lets
 // temporary effects avoid restoring over a newer owner's explicit command.
 uint32_t getFaceCommandRevision();
+
+// Temporarily replace the animated face with the exact JPEG returned by the
+// camera endpoint. The latest requested face is redrawn after the preview.
+bool showCameraPreview(const uint8_t* jpegData, size_t jpegLen,
+                       uint32_t durationMs = 6000);

--- a/firmware/src/http_server.cpp
+++ b/firmware/src/http_server.cpp
@@ -582,6 +582,10 @@ static void handleSnapshot() {
         return;
     }
 
+    if (!showCameraPreview(jpgBuf, jpgLen)) {
+        Serial.println("[HTTP] Camera preview unavailable; returning JPEG normally");
+    }
+
     server.send_P(200, "image/jpeg", (const char*)jpgBuf, jpgLen);
     free(jpgBuf);
     Serial.printf("[HTTP] GET /snapshot -> %u bytes JPEG\n", (unsigned)jpgLen);


### PR DESCRIPTION
## Summary
- show the exact JPEG returned by `/snapshot` on the Stack-chan display for six seconds
- arbitrate display access so animated GIF faces cannot overwrite the preview
- redraw the latest requested face after the preview and keep camera responses working if preview rendering fails

## Verification
- `cd firmware && pio run -e m5stack-cores3`
- `make test-firmware-cpp` (27 passed)
- `make lint-firmware` (no defects)
- `make test-python` (113 passed)
- flashed to CoreS3 and verified a 320x240 JPEG, six-second preview log, face restoration, and touch bus recovery