### PR TITLE
Fix face tracking on slow remote links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,10 +68,13 @@ STACKCHAN_FRONTEND_RETRY_DELAY="3"
 # and run scripts/stackchan_face_tracker.py as one long-lived process. Wake-word
 # or short-touch voice delivery and stackchan_say extend a local tracking lease.
 STACKCHAN_FACE_TRACKING="0"
+# Also acts as the minimum lease for short stackchan_say calls. Increase this
+# when camera frames cross a high-latency remote link.
 STACKCHAN_FACE_TRACK_DURATION_SEC="8"
 STACKCHAN_FACE_TRACK_FPS="2.5"
 STACKCHAN_FACE_TRACK_LOST_SEC="1.8"
 STACKCHAN_FACE_TRACK_SPEED="18"
+STACKCHAN_FACE_TRACK_ACQUIRE_FRAMES="2"
 # Flip either value between -1 and 1 if the physical servo/camera orientation
 # makes that axis turn away from the face.
 STACKCHAN_FACE_TRACK_YAW_DIRECTION="-1"

--- a/.env.example
+++ b/.env.example
@@ -75,6 +75,9 @@ STACKCHAN_FACE_TRACK_FPS="2.5"
 STACKCHAN_FACE_TRACK_LOST_SEC="1.8"
 STACKCHAN_FACE_TRACK_SPEED="18"
 STACKCHAN_FACE_TRACK_ACQUIRE_FRAMES="2"
+# 0 keeps following for the whole lease. On a high-latency relay, 1 takes one
+# frame, turns once, releases the camera, and holds that pose for playback.
+STACKCHAN_FACE_TRACK_MAX_FRAMES="0"
 # Flip either value between -1 and 1 if the physical servo/camera orientation
 # makes that axis turn away from the face.
 STACKCHAN_FACE_TRACK_YAW_DIRECTION="-1"
@@ -83,3 +86,5 @@ STACKCHAN_FACE_TRACK_PITCH_DIRECTION="-1"
 # restores touch automatically if no frame arrives before this watchdog expires.
 # High-latency remote links may need up to the firmware maximum of 15000.
 STACKCHAN_FACE_TRACK_CAMERA_TIMEOUT_MS="5000"
+# This is the separate host-side HTTP response timeout for each JPEG transfer.
+STACKCHAN_HTTP_SNAPSHOT_TIMEOUT_SEC="10"

--- a/.env.example
+++ b/.env.example
@@ -81,4 +81,5 @@ STACKCHAN_FACE_TRACK_YAW_DIRECTION="-1"
 STACKCHAN_FACE_TRACK_PITCH_DIRECTION="-1"
 # During a burst the camera temporarily owns the top-touch I2C pins. Firmware
 # restores touch automatically if no frame arrives before this watchdog expires.
+# High-latency remote links may need up to the firmware maximum of 15000.
 STACKCHAN_FACE_TRACK_CAMERA_TIMEOUT_MS="5000"

--- a/firmware/src/camera_service.cpp
+++ b/firmware/src/camera_service.cpp
@@ -1,4 +1,6 @@
 #include "camera_service.h"
+#include "pcm_stream_service.h"
+#include "playback_service.h"
 #include "touch_service.h"
 #include "esp_camera.h"
 #include "img_converters.h"
@@ -132,7 +134,15 @@ static bool releaseCameraBus() {
     return touchRestored;
 }
 
+static bool audioPlaybackOwnsRuntime() {
+    return isPlaybackActive() || isPcmStreamActive() || M5.Speaker.isPlaying();
+}
+
 bool startCameraSession(uint32_t idleTimeoutMs) {
+    if (audioPlaybackOwnsRuntime()) {
+        Serial.println("[CAM] Burst session rejected while audio playback is active");
+        return false;
+    }
     cameraSessionTimeoutMs = clampSessionTimeout(idleTimeoutMs);
     if (cameraSessionActive) {
         refreshCameraSessionDeadline();
@@ -191,6 +201,11 @@ bool captureJpeg(uint8_t** outBuf, size_t* outLen, int quality) {
     }
     *outBuf = nullptr;
     *outLen = 0;
+
+    if (audioPlaybackOwnsRuntime()) {
+        Serial.println("[CAM] Snapshot rejected while audio playback is active");
+        return false;
+    }
 
     const bool ownsCamera = !cameraSessionActive;
     if (ownsCamera && !acquireCameraBus()) {

--- a/firmware/src/pcm_stream_service.cpp
+++ b/firmware/src/pcm_stream_service.cpp
@@ -7,6 +7,7 @@
 #include <queue>
 
 #include "audio_gate.h"
+#include "camera_service.h"
 #include "config_loader.h"
 #include "face_service.h"
 #include "playback_service.h"
@@ -804,7 +805,10 @@ static void handleStreamClient(WiFiClient client) {
         s_clientConnected = false;
         return;
     }
-    if (s_active || s_udpActive || isPlaybackActive() || M5.Speaker.isPlaying()) {
+    if (
+        s_active || s_udpActive || isPlaybackActive() || isCameraSessionActive()
+        || M5.Speaker.isPlaying()
+    ) {
         client.print("ERR BUSY\n");
         client.stop();
         s_clientConnected = false;
@@ -870,7 +874,10 @@ UdpPcmSessionResult beginUdpPcmSession() {
         }
         memset(s_udpRing, 0, sizeof(UdpFrameSlot) * PCM_UDP_RING_FRAMES);
     }
-    if (s_active || s_playing || s_udpActive || s_udpPlaying || isPlaybackActive() || M5.Speaker.isPlaying()) {
+    if (
+        s_active || s_playing || s_udpActive || s_udpPlaying || isPlaybackActive()
+        || isCameraSessionActive() || M5.Speaker.isPlaying()
+    ) {
         result.error = "busy";
         return result;
     }

--- a/firmware/src/playback_service.cpp
+++ b/firmware/src/playback_service.cpp
@@ -7,6 +7,7 @@
 #include "face_service.h"
 #include "wav_parser.h"
 #include "audio_gate.h"
+#include "camera_service.h"
 #include "pcm_stream_service.h"
 
 struct PlaybackRuntimeState {
@@ -375,7 +376,7 @@ static bool startDownloadedWavPlayback(uint8_t* wavData, size_t wavSize) {
 }
 
 static void checkPendingPlayback() {
-    if (s_isPlaying || !s_downloadCompleteQueue) {
+    if (s_isPlaying || isCameraSessionActive() || !s_downloadCompleteQueue) {
         return;
     }
 
@@ -407,7 +408,10 @@ PcmPlaybackResult startPcmPlayback(uint8_t* pcmData, size_t pcmSize, const Strin
         Serial.printf("[PCM] Invalid size: %u\n", (unsigned)pcmSize);
         return PCM_PLAYBACK_INVALID;
     }
-    if (s_isPlaying || isPcmStreamActive() || M5.Speaker.isPlaying()) {
+    if (
+        s_isPlaying || isPcmStreamActive() || isCameraSessionActive()
+        || M5.Speaker.isPlaying()
+    ) {
         if (s_playbackState.currentIsPcm && sessionId == s_playbackState.pcmSessionId &&
             enqueuePcmBuffer(pcmData, pcmSize, sessionId, finalSegment)) {
             return PCM_PLAYBACK_QUEUED;

--- a/mcp_server/face_tracking.py
+++ b/mcp_server/face_tracking.py
@@ -205,6 +205,7 @@ class FaceTrackingSettings:
     min_command_delta: float = 1.0
     min_command_interval: float = 0.3
     acquire_frames: int = 2
+    max_frames_per_trigger: int = 0
     speed: int = 18
 
     @classmethod
@@ -215,6 +216,17 @@ class FaceTrackingSettings:
         pitch_max = max(
             pitch_min,
             min(env_float("STACKCHAN_FACE_TRACK_PITCH_MAX", 55.0), 90.0),
+        )
+        acquire_frames = max(
+            1, min(env_int("STACKCHAN_FACE_TRACK_ACQUIRE_FRAMES", 2), 5)
+        )
+        configured_max_frames = max(
+            0, min(env_int("STACKCHAN_FACE_TRACK_MAX_FRAMES", 0), 300)
+        )
+        max_frames_per_trigger = (
+            0
+            if configured_max_frames == 0
+            else max(acquire_frames, configured_max_frames)
         )
         return cls(
             fps=max(0.5, min(env_float("STACKCHAN_FACE_TRACK_FPS", 2.5), 5.0)),
@@ -267,7 +279,8 @@ class FaceTrackingSettings:
             min_command_interval=max(
                 0.05, min(env_float("STACKCHAN_FACE_TRACK_COMMAND_INTERVAL_SEC", 0.3), 2.0)
             ),
-            acquire_frames=max(1, min(env_int("STACKCHAN_FACE_TRACK_ACQUIRE_FRAMES", 2), 5)),
+            acquire_frames=acquire_frames,
+            max_frames_per_trigger=max_frames_per_trigger,
             speed=max(1, min(env_int("STACKCHAN_FACE_TRACK_SPEED", 18), 100)),
         )
 

--- a/mcp_server/mcp_tools.py
+++ b/mcp_server/mcp_tools.py
@@ -19,7 +19,7 @@ from .stackchan_client import (
     post_pcm_tcp_stream,
     post_pcm_udp_stream,
 )
-from .stackchan_config import VALID_FACES, StackchanConfig, config_summary
+from .stackchan_config import VALID_FACES, StackchanConfig, config_summary, env_float
 from .telemetry import emit_event, new_request_id
 from .voice_inbox import clear_events, format_events, read_events
 
@@ -54,8 +54,13 @@ def format_speech_confirmation(text: str) -> str:
 
 def speech_tracking_duration(text: str) -> float:
     # Start looking while TTS is generated, then stay engaged for the estimated
-    # spoken duration. The lease is capped again by signal_face_tracking().
-    return max(6.0, min(24.0, 3.0 + len(text) / 4.0))
+    # spoken duration. Slow remote camera links can set a larger deployment
+    # minimum through the same lease-duration setting used by voice triggers.
+    configured_minimum = max(
+        1.0,
+        min(env_float("STACKCHAN_FACE_TRACK_DURATION_SEC", 8.0), 30.0),
+    )
+    return max(configured_minimum, min(30.0, 3.0 + len(text) / 4.0))
 
 
 def audit_tool_call(name: str, **attributes: object) -> None:

--- a/scripts/stackchan_face_tracker.py
+++ b/scripts/stackchan_face_tracker.py
@@ -87,6 +87,7 @@ class FaceTracker:
         self.tracking_started_at = 0.0
         self.last_face_at: float | None = None
         self.previous_face_center: tuple[float, float] | None = None
+        self.frames_seen = 0
 
     def request_stop(self, _signum: int | None = None, _frame: FrameType | None = None) -> None:
         self.running = False
@@ -118,6 +119,7 @@ class FaceTracker:
         self.tracking_started_at = time.monotonic()
         self.last_face_at = None
         self.previous_face_center = None
+        self.frames_seen = 0
         logger.info("Tracking started: sequence=%d reason=%s", lease.sequence, lease.reason)
         return True
 
@@ -143,10 +145,14 @@ class FaceTracker:
         self.controller.reset()
         self.previous_face_center = None
         self.last_face_at = None
+        self.frames_seen = 0
         self.dormant_sequence = dormant_sequence
 
+    def _frame_budget_reached(self) -> bool:
+        limit = self.settings.max_frames_per_trigger
+        return limit > 0 and self.frames_seen >= limit
+
     def _frame(self, lease: TrackingLease) -> None:
-        now = time.monotonic()
         try:
             jpeg_data, _size = self.client.snapshot_once(
                 preview=False,
@@ -161,6 +167,9 @@ class FaceTracker:
             self._end(home=True, dormant_sequence=lease.sequence)
             return
 
+        now = time.monotonic()
+        self.frames_seen += 1
+
         if not read_tracking_lease(self.state_path).active():
             logger.info("Tracking lease expired while the frame was in transit")
             self._end(home=True)
@@ -169,7 +178,10 @@ class FaceTracker:
         face = select_face(faces, self.previous_face_center)
         if face is None:
             absent_since = self.last_face_at or self.tracking_started_at
-            if now - absent_since >= self.settings.lost_timeout_seconds:
+            if (
+                self._frame_budget_reached()
+                or now - absent_since >= self.settings.lost_timeout_seconds
+            ):
                 logger.info("No face visible; returning home and sleeping until the next trigger")
                 self._end(home=True, dormant_sequence=lease.sequence)
             return
@@ -183,6 +195,9 @@ class FaceTracker:
             now=now,
         )
         if command is None:
+            if self._frame_budget_reached():
+                logger.info("Tracking frame budget reached; holding the current pose")
+                self._end(home=False, dormant_sequence=lease.sequence)
             return
 
         try:
@@ -205,6 +220,9 @@ class FaceTracker:
             )
         elif result.get("error") != "gesture active":
             logger.warning("Face-tracking move was rejected: %s", result)
+        if self._frame_budget_reached():
+            logger.info("Tracking frame budget reached; holding the current pose")
+            self._end(home=False, dormant_sequence=lease.sequence)
 
     def run(self, *, once: bool = False) -> int:
         frame_interval = 1.0 / self.settings.fps

--- a/scripts/stackchan_face_tracker.py
+++ b/scripts/stackchan_face_tracker.py
@@ -45,6 +45,7 @@ class OpenCvFaceDetector:
         self.detector = self.cv2.CascadeClassifier(str(cascade_path))
         if self.detector.empty():
             raise RuntimeError(f"Could not load OpenCV face cascade: {cascade_path}")
+        self.equalizer = self.cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
         self.min_face_pixels = min_face_pixels
 
     def detect(self, jpeg_data: bytes) -> tuple[list[FaceBox], int, int]:
@@ -53,10 +54,10 @@ class OpenCvFaceDetector:
         if image is None:
             raise ValueError("Camera returned an invalid JPEG")
         gray = self.cv2.cvtColor(image, self.cv2.COLOR_BGR2GRAY)
-        gray = self.cv2.equalizeHist(gray)
+        gray = self.equalizer.apply(gray)
         found = self.detector.detectMultiScale(
             gray,
-            scaleFactor=1.1,
+            scaleFactor=1.05,
             minNeighbors=5,
             minSize=(self.min_face_pixels, self.min_face_pixels),
         )

--- a/tests/test_face_tracker.py
+++ b/tests/test_face_tracker.py
@@ -1,0 +1,116 @@
+from typing import Any, cast
+
+from mcp_server.face_tracking import (
+    FaceBox,
+    FaceTrackingSettings,
+    read_tracking_lease,
+    signal_face_tracking,
+)
+from scripts.stackchan_face_tracker import FaceTracker
+
+
+class FakeClient:
+    def __init__(self):
+        self.moves: list[tuple[float, float, int, bool]] = []
+        self.stop_count = 0
+        self.home_count = 0
+
+    def start_camera_session(self, idle_timeout_ms: int) -> dict:
+        return {"success": True, "idle_timeout_ms": idle_timeout_ms}
+
+    def stop_camera_session(self) -> dict:
+        self.stop_count += 1
+        return {"success": True}
+
+    def servo_status(self) -> dict:
+        return {
+            "yaw": {"position": 0},
+            "pitch": {"position": 300},
+        }
+
+    def snapshot_once(self, *, preview: bool, camera_session: bool):
+        assert preview is False
+        assert camera_session is True
+        return b"jpeg", 4
+
+    def move(
+        self,
+        yaw: float,
+        pitch: float,
+        speed: int,
+        *,
+        interrupt_gesture: bool,
+    ) -> dict:
+        self.moves.append((yaw, pitch, speed, interrupt_gesture))
+        return {"success": True}
+
+    def gesture(self, name: str) -> dict:
+        assert name == "home"
+        self.home_count += 1
+        return {"success": True}
+
+
+class FakeDetector:
+    def __init__(self, faces: list[FaceBox]):
+        self.faces = faces
+
+    def detect(self, jpeg_data: bytes):
+        assert jpeg_data == b"jpeg"
+        return self.faces, 320, 240
+
+
+def tracker_settings() -> FaceTrackingSettings:
+    return FaceTrackingSettings(
+        acquire_frames=1,
+        max_frames_per_trigger=1,
+        smoothing_alpha=1.0,
+        min_command_interval=0.0,
+    )
+
+
+def active_lease(state_path):
+    assert signal_face_tracking(
+        "test", duration=10, path=state_path, enabled=True
+    )
+    return read_tracking_lease(state_path)
+
+
+def test_one_frame_mode_releases_camera_and_holds_detected_pose(tmp_path):
+    state_path = tmp_path / "tracking.json"
+    client = FakeClient()
+    tracker = FaceTracker(
+        cast(Any, client),
+        cast(Any, FakeDetector([FaceBox(240, 90, 50, 50)])),
+        tracker_settings(),
+        state_path=state_path,
+    )
+    lease = active_lease(state_path)
+
+    assert tracker._begin(lease)
+    tracker._frame(lease)
+
+    assert client.moves
+    assert client.stop_count == 1
+    assert client.home_count == 0
+    assert tracker.camera_active is False
+    assert tracker.dormant_sequence == lease.sequence
+
+
+def test_one_frame_mode_returns_home_when_no_face_is_visible(tmp_path):
+    state_path = tmp_path / "tracking.json"
+    client = FakeClient()
+    tracker = FaceTracker(
+        cast(Any, client),
+        cast(Any, FakeDetector([])),
+        tracker_settings(),
+        state_path=state_path,
+    )
+    lease = active_lease(state_path)
+
+    assert tracker._begin(lease)
+    tracker._frame(lease)
+
+    assert client.moves == []
+    assert client.stop_count == 1
+    assert client.home_count == 1
+    assert tracker.dormant_sequence == lease.sequence

--- a/tests/test_face_tracking.py
+++ b/tests/test_face_tracking.py
@@ -47,6 +47,22 @@ def test_signal_face_tracking_extends_lease_and_increments_sequence(tmp_path):
     assert json.loads(state_path.read_text())["version"] == 1
 
 
+def test_face_tracking_settings_expand_frame_budget_to_acquisition(monkeypatch):
+    monkeypatch.setenv("STACKCHAN_FACE_TRACK_ACQUIRE_FRAMES", "3")
+    monkeypatch.setenv("STACKCHAN_FACE_TRACK_MAX_FRAMES", "1")
+
+    configured = FaceTrackingSettings.from_env()
+
+    assert configured.acquire_frames == 3
+    assert configured.max_frames_per_trigger == 3
+
+
+def test_face_tracking_settings_allow_unbounded_frame_budget(monkeypatch):
+    monkeypatch.setenv("STACKCHAN_FACE_TRACK_MAX_FRAMES", "0")
+
+    assert FaceTrackingSettings.from_env().max_frames_per_trigger == 0
+
+
 def test_select_face_prefers_largest_then_stays_near_previous_target():
     left = FaceBox(10, 20, 50, 50)
     right = FaceBox(210, 20, 70, 70)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -311,10 +311,17 @@ def test_speech_confirmation_omits_transport_diagnostics():
     assert "…" in result
 
 
-def test_speech_tracking_duration_is_bounded():
-    assert speech_tracking_duration("") == 6.0
+def test_speech_tracking_duration_is_bounded(monkeypatch):
+    monkeypatch.delenv("STACKCHAN_FACE_TRACK_DURATION_SEC", raising=False)
+    assert speech_tracking_duration("") == 8.0
     assert speech_tracking_duration("x" * 40) == 13.0
-    assert speech_tracking_duration("x" * 1000) == 24.0
+    assert speech_tracking_duration("x" * 1000) == 30.0
+
+
+def test_speech_tracking_duration_uses_deployment_minimum(monkeypatch):
+    monkeypatch.setenv("STACKCHAN_FACE_TRACK_DURATION_SEC", "20")
+
+    assert speech_tracking_duration("short") == 20.0
 
 
 def test_stackchan_say_audit_log_records_length_without_speech_text(monkeypatch, tmp_path, caplog):


### PR DESCRIPTION
## What changed

- use the configured face-tracking lease as the minimum for short speech
- improve low-light face detection with CLAHE and finer cascade scaling
- document the acquisition-frame setting for high-latency deployments

The local deployment now uses a 20-second lease, one-frame acquisition, and a 45-second audio download timeout. Those ignored host settings are intentionally not committed.

## Checks

- `make lint`
- `make test` (126 Python tests and 27 firmware tests passed)
- `make audit-security`
- real 320x240 low-light camera frame now detects the visible face

## Safety

No credentials, device addresses, recordings, or diagnostic images are included.