### PR TITLE
fix(tracking): detect backlit faces

### DIFF
--- a/scripts/stackchan_face_tracker.py
+++ b/scripts/stackchan_face_tracker.py
@@ -48,19 +48,28 @@ class OpenCvFaceDetector:
         self.equalizer = self.cv2.createCLAHE(clipLimit=2.0, tileGridSize=(8, 8))
         self.min_face_pixels = min_face_pixels
 
+    def _detect_boxes(self, gray: Any) -> Any:
+        options = {
+            "scaleFactor": 1.05,
+            "minNeighbors": 5,
+            "minSize": (self.min_face_pixels, self.min_face_pixels),
+        }
+        found = self.detector.detectMultiScale(self.equalizer.apply(gray), **options)
+        if len(found) == 0:
+            # Global equalization is a useful fallback for strongly backlit faces.
+            found = self.detector.detectMultiScale(
+                self.cv2.equalizeHist(gray),
+                **options,
+            )
+        return found
+
     def detect(self, jpeg_data: bytes) -> tuple[list[FaceBox], int, int]:
         encoded = self.np.frombuffer(jpeg_data, dtype=self.np.uint8)
         image = self.cv2.imdecode(encoded, self.cv2.IMREAD_COLOR)
         if image is None:
             raise ValueError("Camera returned an invalid JPEG")
         gray = self.cv2.cvtColor(image, self.cv2.COLOR_BGR2GRAY)
-        gray = self.equalizer.apply(gray)
-        found = self.detector.detectMultiScale(
-            gray,
-            scaleFactor=1.05,
-            minNeighbors=5,
-            minSize=(self.min_face_pixels, self.min_face_pixels),
-        )
+        found = self._detect_boxes(gray)
         faces = [FaceBox(int(x), int(y), int(width), int(height)) for x, y, width, height in found]
         height, width = gray.shape[:2]
         return faces, width, height

--- a/tests/test_face_tracker.py
+++ b/tests/test_face_tracker.py
@@ -6,7 +6,7 @@ from mcp_server.face_tracking import (
     read_tracking_lease,
     signal_face_tracking,
 )
-from scripts.stackchan_face_tracker import FaceTracker
+from scripts.stackchan_face_tracker import FaceTracker, OpenCvFaceDetector
 
 
 class FakeClient:
@@ -59,6 +59,27 @@ class FakeDetector:
         return self.faces, 320, 240
 
 
+class FakeCascade:
+    def __init__(self, results):
+        self.results = iter(results)
+        self.frames = []
+
+    def detectMultiScale(self, frame, **_options):
+        self.frames.append(frame)
+        return next(self.results)
+
+
+class FakeEqualizer:
+    def apply(self, _gray):
+        return "local"
+
+
+class FakeCv2:
+    @staticmethod
+    def equalizeHist(_gray):
+        return "global"
+
+
 def tracker_settings() -> FaceTrackingSettings:
     return FaceTrackingSettings(
         acquire_frames=1,
@@ -73,6 +94,29 @@ def active_lease(state_path):
         "test", duration=10, path=state_path, enabled=True
     )
     return read_tracking_lease(state_path)
+
+
+def face_detector_with_results(results):
+    detector = OpenCvFaceDetector.__new__(OpenCvFaceDetector)
+    detector.detector = FakeCascade(results)
+    detector.equalizer = FakeEqualizer()
+    detector.cv2 = FakeCv2()
+    detector.min_face_pixels = 36
+    return detector
+
+
+def test_face_detector_uses_global_equalization_after_local_miss():
+    detector = face_detector_with_results([[], [(120, 16, 89, 89)]])
+
+    assert detector._detect_boxes("gray") == [(120, 16, 89, 89)]
+    assert detector.detector.frames == ["local", "global"]
+
+
+def test_face_detector_skips_fallback_after_local_hit():
+    detector = face_detector_with_results([[(100, 20, 80, 80)]])
+
+    assert detector._detect_boxes("gray") == [(100, 20, 80, 80)]
+    assert detector.detector.frames == ["local"]
 
 
 def test_one_frame_mode_releases_camera_and_holds_detected_pose(tmp_path):


### PR DESCRIPTION
## Summary
- keep CLAHE as the primary face-detection pass
- retry with global histogram equalization when the primary pass finds no face
- cover both fallback and fast-path behavior

## Verification
- `uv run --extra face-tracking pytest -q` (132 passed)
- `make lint`
- live 320x240 backlit frame detected at x=120, y=16, w=89, h=89
- live tracker command: yaw=-7.3, pitch=5.0, speed=18